### PR TITLE
Reorganize Smoother

### DIFF
--- a/tests/compare_result.py
+++ b/tests/compare_result.py
@@ -48,7 +48,7 @@ def compare_energyresult(output_dir, rootdir):
             E_titles_ref, data_energy_ref, data_ref, data_smooth_ref = read_energyresult_dat(path_filename_ref)
 
             assert E_titles == E_titles_ref
-            # assert data_energy == approx(data_energy_ref, abs=precision)
+            assert data_energy == approx(data_energy_ref, abs=precision)
             assert data == approx(data_ref, abs=precision), error_message(
                 fout_name, suffix, i_iter, np.max(np.abs(data - data_ref)), path_filename, path_filename_ref)
             assert data_smooth == approx(data_smooth_ref, abs=precision), "smoothed " + error_message(

--- a/tests/test_smoother.py
+++ b/tests/test_smoother.py
@@ -1,0 +1,53 @@
+"""Test the Smoother classes"""
+
+import numpy as np
+import pytest
+from pytest import approx
+
+import wannierberri as wberri
+from wannierberri.__utility import *
+
+def test_smoother():
+    np.random.seed(123)
+
+    # Instantiation of an abstract class should fail
+    with pytest.raises(TypeError):
+        sm_abstract = AbstractSmoother()
+
+    # Test VoidSmoother. A do-nothing smoother
+    sm_void = VoidSmoother()
+    data = np.random.rand(3, 4)
+    assert sm_void(data) == approx(data, abs=1E-10)
+
+    # Test nontrivial smoothers
+    e = np.arange(-1.0, 1.1, 0.1)
+    data = np.zeros((len(e),))
+    data[10] = 1.0
+    for smoother, param in [(GaussianSmoother, 0.1), (FermiDiracSmoother, 1000.0)]:
+        sm = smoother(e, param)
+        target = sm._broaden(e)* sm.dE
+        target /= np.sum(target[10-sm.NE1:10+sm.NE1+1])
+        assert sm(data)[9:12] == approx(target[9:12], abs=1E-10)
+        assert np.all(sm(data)[:10-sm.NE1] == 0.0)
+        assert np.all(sm(data)[10+sm.NE1+1:] == 0.0)
+
+    # Test nontrivial smoothers for high-dimensional data
+    e = np.arange(-1.0, 1.1, 0.1)
+    data_1d = np.random.rand(len(e))
+    data_3d = np.zeros((2, len(e), 3))
+    data_3d[...] = data_1d[None, :, None]
+    for smoother, param in [(GaussianSmoother, 0.1), (FermiDiracSmoother, 1000.0)]:
+        sm = smoother(e, param)
+        sm_data_1d = sm(data_1d)
+        sm_data_3d = sm(data_3d, axis=1)
+        assert sm_data_3d - sm_data_1d[None, :, None] == approx(0.0, abs=1E-10)
+
+    # Test getSmoother
+    assert getSmoother(e, None) == VoidSmoother()
+    assert getSmoother(None, None) == VoidSmoother()
+    assert getSmoother([0.0], 1.0) == VoidSmoother()
+    assert getSmoother(e, 0.1, "Gaussian") == GaussianSmoother(e, 0.1)
+    assert getSmoother(e, 0.1, "Fermi-Dirac") == FermiDiracSmoother(e, 0.1)
+    assert getSmoother(e, 0.2, "Gaussian") != GaussianSmoother(e, 0.1)
+    assert getSmoother(e + 0.1, 0.2, "Gaussian") != GaussianSmoother(e, 0.1)
+    assert getSmoother(e, 0.1, "Gaussian") != FermiDiracSmoother(e, 0.1)

--- a/wannierberri/__main.py
+++ b/wannierberri/__main.py
@@ -168,8 +168,8 @@ def integrate(system,grid,Efermi=None,omega=None, Ef0=0,
     if smearW is not None:
         print( "WARNING : smearW parameteris neglected, smearing is currently done inside the kubo routine, use  kBT parameter")
         smearW=None
-    smoothEf = getSmoother(Efermi,smearEf) # smoother for functions of Fermi energy
-    smoothW  = getSmoother(omega,smearW) # smoother for functions of frequency
+    smoothEf = getSmoother(Efermi, smearEf, "Fermi-Dirac") # smoother for functions of Fermi energy
+    smoothW  = getSmoother(omega,  smearW,  "Fermi-Dirac") # smoother for functions of frequency
 
     eval_func=functools.partial( __integrate.intProperty, Efermi=Efermi, omega=omega, smootherEf=smoothEf, smootherOmega=smoothW,
             quantities=quantities, parameters=parameters )

--- a/wannierberri/__main.py
+++ b/wannierberri/__main.py
@@ -169,7 +169,8 @@ def integrate(system,grid,Efermi=None,omega=None, Ef0=0,
         print( "WARNING : smearW parameteris neglected, smearing is currently done inside the kubo routine, use  kBT parameter")
         smearW=None
     smoothEf = getSmoother(Efermi, smearEf, "Fermi-Dirac") # smoother for functions of Fermi energy
-    smoothW  = getSmoother(omega,  smearW,  "Fermi-Dirac") # smoother for functions of frequency
+    smoothW  = getSmoother(omega,  smearW) # smoother for functions of frequency
+    # smoothW  = getSmoother(omega,  smearW,  "Gaussian") # smoother for functions of frequency
 
     eval_func=functools.partial( __integrate.intProperty, Efermi=Efermi, omega=omega, smootherEf=smoothEf, smootherOmega=smoothW,
             quantities=quantities, parameters=parameters )

--- a/wannierberri/__utility.py
+++ b/wannierberri/__utility.py
@@ -167,16 +167,16 @@ class FermiDiracSmoother(AbstractSmoother):
     """
     _params = ['smear', 'E', 'maxdE', 'NE1']
 
-    def __init__(self, E, T_Kelvin=10.0, maxdE=8):
+    def __init__(self, E, T_Kelvin, maxdE=8):
         self.T_Kelvin = T_Kelvin
-        T_eV = T_Kelvin * Boltzmann / elementary_charge  # convert K to eV
-        super().__init__(E, T_eV, maxdE)
+        smear = T_Kelvin * Boltzmann / elementary_charge  # convert K to eV
+        super().__init__(E, smear, maxdE)
 
     def _broaden(self,E):
         return 0.25 / self.smear / np.cosh(E/(2*self.smear))**2
 
     def __str__(self):
-        return f"<FermiDiracSmoother T={self.smear}, NE={self.NE}, NE1={self.NE1}, E={self.Emin}..{self.Emax}, step {self.dE}>"
+        return f"<FermiDiracSmoother T={self.smear} ({self.T_Kelvin:.1f} K), NE={self.NE}, NE1={self.NE1}, E={self.Emin}..{self.Emax}, step {self.dE}>"
 
 
 class GaussianSmoother(AbstractSmoother):
@@ -229,7 +229,7 @@ def getSmoother(energy, smear, mode=None):
     elif mode == "Gaussian":
         return GaussianSmoother(energy, smear)
     else:
-        raise ValueError("mode must be Fermi-Dirac")
+        raise ValueError("Smoother mode not recognized.")
 
 
 def str2bool(v):


### PR DESCRIPTION
I reorganized the Smoother modules. The purpose is to make implementation of new Smoothers easier.

I defined an AbstractSmoother, which defines `smt`, `__call__`, and a few other methods, but not `_broaden`. Each specific Smoother inherits the AbstractSmoother and only implements its own `_broaden`. VoidSmoother is a special case in which `__call__` is also overriden.

I renamed `Smoother` to `FermiDiracSmoother` and added `GaussianSmoother`. Currently, `GaussianSmoother` is not used in the code, but later it might be possible to use it to smooth functions of frequencies, in e.g. Kubo routines. (But it needs some thinking because for frequencies, in the zero-smearing limit, we have delta functions, not step functions as for occupations.)

Also, I moved some LazyProperties to `__init__` because they were just a few real numbers.