### PR TITLE
Ray fix for error on shutdown

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
     timeout-minutes: 20
     strategy:
       matrix:
-        python-version: [ 3.7, 3.8]
+        python-version: [3.6, 3.7, 3.8]
         install-type: [dev]
 
     steps:

--- a/tutorial/example.py
+++ b/tutorial/example.py
@@ -56,3 +56,10 @@ wberri.tabulate(system,
              parallel=parallel,
              ibands=np.arange(4,10),
              Ef0=12.6)
+
+
+# Shutdown Parallel object.
+# This line is not actually needed here and is added just for illustrative purpose.
+# It is needed only when one wants to close and reopen a new parallel object.
+parallel.shutdown()
+

--- a/wannierberri/__parallel.py
+++ b/wannierberri/__parallel.py
@@ -77,7 +77,7 @@ class Parallel():
                     )
 
 
-    def __del__(self):
+    def shutdown(self):
         if self.method == "ray":
             self.ray.shutdown()
 


### PR DESCRIPTION
With the new Parallel class, using ray was giving error when shutting down python (can be reproduced by running example.py in tutorial). The reason is that `__del__` is called when shutting down python, but imported modules are already deleted, so python cannot run `ray.shutdown()`.

This error may be related to https://github.com/wannier-berri/wannier-berri/pull/52#issuecomment-886157263.

Here, I renamed `__del__` to `shutdown` so that it is not called when shutting down python. Users can close their Parallel object by `parallel.shutdown()`. I also added python 3.6 test.