### PR TITLE
Various fixes

### DIFF
--- a/tests/compare_result.py
+++ b/tests/compare_result.py
@@ -6,7 +6,7 @@ import numpy as np
 import pytest
 from pytest import approx
 
-from conftest import rootdir, output_dir
+from conftest import ROOT_DIR, OUTPUT_DIR
 
 def read_energyresult_dat(filename):
     """Read .dat file output of EnergyResult."""
@@ -44,9 +44,9 @@ def compare_energyresult():
         for i_iter in range(adpt_num_iter+1):
             filename     = fout_name + f"-{suffix}_iter-{i_iter:04d}.dat"
             filename_ref = fout_name + f"-{suffix_ref}_iter-{i_iter:04d}.dat"
-            path_filename = os.path.join(output_dir(), filename)
+            path_filename = os.path.join(OUTPUT_DIR, filename)
             E_titles, data_energy, data, data_smooth = read_energyresult_dat(path_filename)
-            path_filename_ref = os.path.join(rootdir(), 'reference', filename_ref)
+            path_filename_ref = os.path.join(ROOT_DIR, 'reference', filename_ref)
             E_titles_ref, data_energy_ref, data_ref, data_smooth_ref = read_energyresult_dat(path_filename_ref)
 
             if precision is None:

--- a/tests/compare_result.py
+++ b/tests/compare_result.py
@@ -6,6 +6,8 @@ import numpy as np
 import pytest
 from pytest import approx
 
+from conftest import rootdir, output_dir
+
 def read_energyresult_dat(filename):
     """Read .dat file output of EnergyResult."""
     data_raw = np.loadtxt(filename)
@@ -34,7 +36,7 @@ def error_message(fout_name, suffix, i_iter, abs_err, filename, filename_ref):
 
 
 @pytest.fixture
-def compare_energyresult(output_dir, rootdir):
+def compare_energyresult():
     """Compare dat file output of EnergyResult with the file in reference folder"""
     def _inner(fout_name, suffix, adpt_num_iter,suffix_ref=None,precision=None):
         if suffix_ref is None :
@@ -42,9 +44,9 @@ def compare_energyresult(output_dir, rootdir):
         for i_iter in range(adpt_num_iter+1):
             filename     = fout_name + f"-{suffix}_iter-{i_iter:04d}.dat"
             filename_ref = fout_name + f"-{suffix_ref}_iter-{i_iter:04d}.dat"
-            path_filename = os.path.join(output_dir, filename)
+            path_filename = os.path.join(output_dir(), filename)
             E_titles, data_energy, data, data_smooth = read_energyresult_dat(path_filename)
-            path_filename_ref = os.path.join(rootdir, 'reference', filename_ref)
+            path_filename_ref = os.path.join(rootdir(), 'reference', filename_ref)
             E_titles_ref, data_energy_ref, data_ref, data_smooth_ref = read_energyresult_dat(path_filename_ref)
 
             if precision is None:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,14 +5,12 @@ import os
 import numpy
 import pytest
 
-@pytest.fixture(scope="session")
 def rootdir():
     return os.path.dirname(os.path.abspath(__file__))
 
-@pytest.fixture(scope="session", autouse=True)
-def output_dir(rootdir):
+def output_dir():
     from pathlib import Path
-    directory = os.path.join(rootdir, "_dat_files")
+    directory = os.path.join(rootdir(), "_dat_files")
     Path(directory).mkdir(exist_ok=True)
     return directory
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -36,6 +36,12 @@ def parallel_serial():
 @pytest.fixture(scope="session")
 def parallel_ray():
     from wannierberri import Parallel
+    # If multiple ray parallel setups are tested in a single session, the
+    # parallel object needs to be shutdown before changing the setup.
+    # To do so, one needs to change the scope to function, use yield instead
+    # of return, and add parallel.shutdown() after the yield statement.
+    # See https://docs.pytest.org/en/6.2.x/fixture.html#yield-fixtures-recommended
+    # Currently, only a single ray setup is used, so this is not a problem.
     return Parallel(
                    method="ray",
                    num_cpus=4  ,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -12,7 +12,7 @@ ROOT_DIR = os.path.dirname(os.path.abspath(__file__))
 OUTPUT_DIR = os.path.join(ROOT_DIR, "_dat_files")
 
 @pytest.fixture(scope="session", autouse=True)
-def create_OUTPUT_DIR():
+def create_output_dir():
     # Create folder OUTPUT_DIR
     from pathlib import Path
     Path(OUTPUT_DIR).mkdir(exist_ok=True)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,15 +5,17 @@ import os
 import numpy
 import pytest
 
-def rootdir():
-    return os.path.dirname(os.path.abspath(__file__))
+# Root folder containing test scripts
+ROOT_DIR = os.path.dirname(os.path.abspath(__file__))
 
-def output_dir():
+# Folder containing output dat files of tests
+OUTPUT_DIR = os.path.join(ROOT_DIR, "_dat_files")
+
+@pytest.fixture(scope="session", autouse=True)
+def create_OUTPUT_DIR():
+    # Create folder OUTPUT_DIR
     from pathlib import Path
-    directory = os.path.join(rootdir(), "_dat_files")
-    Path(directory).mkdir(exist_ok=True)
-    return directory
-
+    Path(OUTPUT_DIR).mkdir(exist_ok=True)
 
 @pytest.fixture(scope="session")
 def parallel_serial():

--- a/tests/create_system.py
+++ b/tests/create_system.py
@@ -11,6 +11,8 @@ import numpy as np
 
 import wannierberri as wberri
 
+from conftest import rootdir
+
 def create_W90_files(seedname, tags_needed, data_dir):
     """
     Extract the compressed amn and mmn data files.
@@ -46,12 +48,12 @@ def create_W90_files(seedname, tags_needed, data_dir):
 
 
 @pytest.fixture(scope="session")
-def create_files_Fe_W90(rootdir):
+def create_files_Fe_W90():
     """Create data files for Fe: uHu, uIu, sHu, and sIu"""
 
     seedname = "Fe"
     tags_needed = ["uHu", "uIu", "sHu", "sIu"] # Files to calculate if they do not exist
-    data_dir = os.path.join(rootdir, "data", "Fe_Wannier90")
+    data_dir = os.path.join(rootdir(), "data", "Fe_Wannier90")
 
     create_W90_files(seedname, tags_needed, data_dir)
 
@@ -59,12 +61,12 @@ def create_files_Fe_W90(rootdir):
 
 
 @pytest.fixture(scope="session")
-def create_files_GaAs_W90(rootdir):
+def create_files_GaAs_W90():
     """Create data files for Fe: uHu, uIu, sHu, and sIu"""
 
     seedname = "GaAs"
     tags_needed = ["uHu", "uIu", "sHu", "sIu"] # Files to calculate if they do not exist
-    data_dir = os.path.join(rootdir, "data", "GaAs_Wannier90")
+    data_dir = os.path.join(rootdir(), "data", "GaAs_Wannier90")
 
     create_W90_files(seedname, tags_needed, data_dir)
 
@@ -160,10 +162,10 @@ def system_GaAs_W90_wcc(create_files_GaAs_W90):
 
 
 @pytest.fixture(scope="session")
-def system_GaAs_tb(rootdir):
+def system_GaAs_tb():
     """Create system for GaAs using _tb.dat data"""
 
-    data_dir = os.path.join(rootdir, "data", "GaAs_Wannier90")
+    data_dir = os.path.join(rootdir(), "data", "GaAs_Wannier90")
     if not os.path.isfile(os.path.join(data_dir, "GaAs_tb.dat")):
         tar = tarfile.open(os.path.join(data_dir, "GaAs_tb.dat.tar.gz"))
         for tarinfo in tar:
@@ -175,10 +177,10 @@ def system_GaAs_tb(rootdir):
     return system
 
 @pytest.fixture(scope="session")
-def system_GaAs_tb_wcc(rootdir):
+def system_GaAs_tb_wcc():
     """Create system for GaAs using _tb_dat data"""
 
-    data_dir = os.path.join(rootdir, "data", "GaAs_Wannier90")
+    data_dir = os.path.join(rootdir(), "data", "GaAs_Wannier90")
     if not os.path.isfile(os.path.join(data_dir, "GaAs_tb.dat")):
         tar = tarfile.open(os.path.join(data_dir, "GaAs_tb.dat.tar.gz"))
         for tarinfo in tar:

--- a/tests/create_system.py
+++ b/tests/create_system.py
@@ -11,7 +11,7 @@ import numpy as np
 
 import wannierberri as wberri
 
-from conftest import rootdir
+from conftest import ROOT_DIR
 
 def create_W90_files(seedname, tags_needed, data_dir):
     """
@@ -53,7 +53,7 @@ def create_files_Fe_W90():
 
     seedname = "Fe"
     tags_needed = ["uHu", "uIu", "sHu", "sIu"] # Files to calculate if they do not exist
-    data_dir = os.path.join(rootdir(), "data", "Fe_Wannier90")
+    data_dir = os.path.join(ROOT_DIR, "data", "Fe_Wannier90")
 
     create_W90_files(seedname, tags_needed, data_dir)
 
@@ -66,7 +66,7 @@ def create_files_GaAs_W90():
 
     seedname = "GaAs"
     tags_needed = ["uHu", "uIu", "sHu", "sIu"] # Files to calculate if they do not exist
-    data_dir = os.path.join(rootdir(), "data", "GaAs_Wannier90")
+    data_dir = os.path.join(ROOT_DIR, "data", "GaAs_Wannier90")
 
     create_W90_files(seedname, tags_needed, data_dir)
 
@@ -165,7 +165,7 @@ def system_GaAs_W90_wcc(create_files_GaAs_W90):
 def system_GaAs_tb():
     """Create system for GaAs using _tb.dat data"""
 
-    data_dir = os.path.join(rootdir(), "data", "GaAs_Wannier90")
+    data_dir = os.path.join(ROOT_DIR, "data", "GaAs_Wannier90")
     if not os.path.isfile(os.path.join(data_dir, "GaAs_tb.dat")):
         tar = tarfile.open(os.path.join(data_dir, "GaAs_tb.dat.tar.gz"))
         for tarinfo in tar:
@@ -180,7 +180,7 @@ def system_GaAs_tb():
 def system_GaAs_tb_wcc():
     """Create system for GaAs using _tb_dat data"""
 
-    data_dir = os.path.join(rootdir(), "data", "GaAs_Wannier90")
+    data_dir = os.path.join(ROOT_DIR, "data", "GaAs_Wannier90")
     if not os.path.isfile(os.path.join(data_dir, "GaAs_tb.dat")):
         tar = tarfile.open(os.path.join(data_dir, "GaAs_tb.dat.tar.gz"))
         for tarinfo in tar:

--- a/tests/test_cluster.py
+++ b/tests/test_cluster.py
@@ -1,6 +1,8 @@
 import os
 import pytest
 
+from conftest import rootdir, output_dir
+
 """
 Test creation of submission scripts for slurm and PBS batch systems.
 No jobs are submitted in the test.
@@ -39,7 +41,7 @@ def compare_texts(script_text, ref_text, variable_strings):
 
 
 @pytest.mark.parametrize("cluster_type", ["slurm", "pbs"])
-def test_cluster_script(cluster_type, rootdir, output_dir, check_command_output):
+def test_cluster_script(cluster_type, check_command_output):
     if cluster_type == "slurm":
         variable_strings = ["#SBATCH --job-name=my_first_job_","#SBATCH --output=my_first_job_"]
     elif cluster_type == "pbs":
@@ -70,6 +72,6 @@ def test_cluster_script(cluster_type, rootdir, output_dir, check_command_output)
     script_name=stdout.split("'")[-2].split()[-1]
     print (script_name)
     script_text = open(script_name,"r").readlines()
-    ref_text    = open(os.path.join(rootdir,"reference",f"my_first_job_{cluster_type}.sh"),"r").readlines()
+    ref_text    = open(os.path.join(rootdir(),"reference",f"my_first_job_{cluster_type}.sh"),"r").readlines()
     compare_texts(script_text, ref_text, variable_strings)
-    os.replace(script_name, os.path.join(output_dir, script_name))
+    os.replace(script_name, os.path.join(output_dir(), script_name))

--- a/tests/test_cluster.py
+++ b/tests/test_cluster.py
@@ -1,7 +1,7 @@
 import os
 import pytest
 
-from conftest import rootdir, output_dir
+from conftest import ROOT_DIR, OUTPUT_DIR
 
 """
 Test creation of submission scripts for slurm and PBS batch systems.
@@ -72,6 +72,6 @@ def test_cluster_script(cluster_type, check_command_output):
     script_name=stdout.split("'")[-2].split()[-1]
     print (script_name)
     script_text = open(script_name,"r").readlines()
-    ref_text    = open(os.path.join(rootdir(),"reference",f"my_first_job_{cluster_type}.sh"),"r").readlines()
+    ref_text    = open(os.path.join(ROOT_DIR,"reference",f"my_first_job_{cluster_type}.sh"),"r").readlines()
     compare_texts(script_text, ref_text, variable_strings)
-    os.replace(script_name, os.path.join(output_dir(), script_name))
+    os.replace(script_name, os.path.join(OUTPUT_DIR, script_name))

--- a/tests/test_formatted.py
+++ b/tests/test_formatted.py
@@ -11,7 +11,7 @@ from wannierberri.__w90_files import UHU, UIU, SHU, SIU, SPN
 from create_system import create_files_GaAs_W90
 
 @pytest.fixture(scope="module")
-def generate_formatted_files(rootdir, create_files_GaAs_W90):
+def generate_formatted_files(create_files_GaAs_W90):
     """Create formatted files for Fe using mmn2uHu"""
 
     data_dir = create_files_GaAs_W90

--- a/tests/test_integrate.py
+++ b/tests/test_integrate.py
@@ -6,7 +6,7 @@ import pytest
 from pytest import approx
 
 import wannierberri as wberri
-from conftest import parallel_serial, parallel_ray, parallel_multiprocessing
+from conftest import output_dir
 from create_system import create_files_Fe_W90,create_files_GaAs_W90,pythtb_Haldane,tbmodels_Haldane
 from create_system import system_Fe_W90,system_GaAs_W90,system_GaAs_tb,system_Haldane_PythTB,system_Haldane_TBmodels
 from create_system import system_Fe_W90_sym, system_Haldane_TBmodels_sym, system_Haldane_PythTB_sym
@@ -15,7 +15,7 @@ from compare_result import compare_energyresult
 
 
 @pytest.fixture
-def check_integrate(output_dir,parallel_serial):
+def check_integrate(parallel_serial):
     def _inner(system,quantities,fout_name,Efermi,comparer,
                parallel=None,
                numproc=0,
@@ -34,7 +34,7 @@ def check_integrate(output_dir,parallel_serial):
                 numproc=numproc,
                 adpt_num_iter = adpt_num_iter,
                 parameters = additional_parameters,
-                fout_name = os.path.join(output_dir, fout_name),
+                fout_name = os.path.join(output_dir(), fout_name),
                 suffix=suffix,
                 restart = False,
                 )

--- a/tests/test_integrate.py
+++ b/tests/test_integrate.py
@@ -6,7 +6,7 @@ import pytest
 from pytest import approx
 
 import wannierberri as wberri
-from conftest import output_dir
+from conftest import OUTPUT_DIR
 from create_system import create_files_Fe_W90,create_files_GaAs_W90,pythtb_Haldane,tbmodels_Haldane
 from create_system import system_Fe_W90,system_GaAs_W90,system_GaAs_tb,system_Haldane_PythTB,system_Haldane_TBmodels
 from create_system import system_Fe_W90_sym, system_Haldane_TBmodels_sym, system_Haldane_PythTB_sym
@@ -34,7 +34,7 @@ def check_integrate(parallel_serial):
                 numproc=numproc,
                 adpt_num_iter = adpt_num_iter,
                 parameters = additional_parameters,
-                fout_name = os.path.join(output_dir(), fout_name),
+                fout_name = os.path.join(OUTPUT_DIR, fout_name),
                 suffix=suffix,
                 restart = False,
                 )

--- a/tests/test_kubo.py
+++ b/tests/test_kubo.py
@@ -7,14 +7,14 @@ from pytest import approx
 
 import wannierberri as wberri
 
-from conftest import parallel_serial
+from conftest import output_dir
 from create_system import create_files_Fe_W90, system_Fe_W90, system_Fe_W90_wcc
 from create_system import create_files_GaAs_W90, system_GaAs_W90, system_GaAs_W90_wcc
 from compare_result import compare_energyresult
 from test_integrate import compare_quant
 
 @pytest.fixture
-def check_integrate_dynamical(output_dir):
+def check_integrate_dynamical():
     """
     This function is similar to check_integrate, but the difference is 1) the shape of the
     data are different for dynamical quantities (has omega index), and 2) opt_conductivity
@@ -33,7 +33,7 @@ def check_integrate_dynamical(output_dir):
                 numproc = numproc,
                 adpt_num_iter = adpt_num_iter,
                 parameters = additional_parameters,
-                fout_name = os.path.join(output_dir, fout_name),
+                fout_name = os.path.join(output_dir(), fout_name),
                 suffix = suffix,
                 restart = False,
                 )

--- a/tests/test_kubo.py
+++ b/tests/test_kubo.py
@@ -7,7 +7,7 @@ from pytest import approx
 
 import wannierberri as wberri
 
-from conftest import output_dir
+from conftest import OUTPUT_DIR
 from create_system import create_files_Fe_W90, system_Fe_W90, system_Fe_W90_wcc
 from create_system import create_files_GaAs_W90, system_GaAs_W90, system_GaAs_W90_wcc
 from compare_result import compare_energyresult
@@ -33,7 +33,7 @@ def check_integrate_dynamical():
                 numproc = numproc,
                 adpt_num_iter = adpt_num_iter,
                 parameters = additional_parameters,
-                fout_name = os.path.join(output_dir(), fout_name),
+                fout_name = os.path.join(OUTPUT_DIR, fout_name),
                 suffix = suffix,
                 restart = False,
                 )

--- a/wannierberri/__w90_files.py
+++ b/wannierberri/__w90_files.py
@@ -113,7 +113,7 @@ class CheckPoint():
                 iknb=mmn.neighbours[ik,ib]
                 data=mmn.data[ik,ib]
                 if eig is not None:
-                    data*=eig.data[ik,:,None]
+                    data = data * eig.data[ik,:,None]
                 AAW=self.wannier_gauge(data,ik,iknb)
                 AA_q_ik=1.j*AAW[:,:,None]*mmn.wk[ik,ib]*mmn.bk_cart[ik,ib,None,None,:]
                 if transl_inv:


### PR DESCRIPTION
1. Fix a bug that `mmn.data` is changed when computing `BB`. This happens when `morb` and `SHCqiao` are both true.

2. Add some comments on `parallel_ray` fixture. If in the future a `Parallel` object with a different ray setting is included in the test suite, one needs to take care to shutdown parallel object before initiating a new one.

3. Make `rootdir` and `output_dir` constant functions. Since their values are not changed, they need not be fixtures. I think same holds for the various parameters in `test_integrate.py`: they can just be constants.
The benefit is that they can be used in non-fixture functions.