### PR TITLE
Set smearW=None as default, fix typos

### DIFF
--- a/wannierberri/__grid.py
+++ b/wannierberri/__grid.py
@@ -98,7 +98,7 @@ class Grid():
                                 K_list[k[0]][k[1]][k[2]]=None
         K_list=[K for Kyz in K_list for Kz in Kyz for K in Kz if K is not None]
         print ("Done in {} s ".format(time()-t0))
-        print ("K_list contains {} Irreducible points({}%%) out of initial {}x{}x{}={} grid".format(len(K_list),round(len(K_list)/np.prod(self.div)*100,2),self.div[0],self.div[1],self.div[2],np.prod(self.div)))
+        print ("K_list contains {} Irreducible points({}%) out of initial {}x{}x{}={} grid".format(len(K_list),round(len(K_list)/np.prod(self.div)*100,2),self.div[0],self.div[1],self.div[2],np.prod(self.div)))
         return K_list
 
 

--- a/wannierberri/__main.py
+++ b/wannierberri/__main.py
@@ -110,7 +110,7 @@ def check_option(quantities,avail,tp):
 ## TODO: Unify the two methids, to do everything in one shot
 
 def integrate(system,grid,Efermi=None,omega=None, Ef0=0,
-                        smearEf=10,smearW=10,quantities=[],adpt_num_iter=0,adpt_fac=1,
+                        smearEf=10,smearW=None,quantities=[],adpt_num_iter=0,adpt_fac=1,
                         fout_name="wberri",restart=False,fftlib='fftw',suffix="",file_Klist="Klist",
                         parallel = None, 
                         parameters={},
@@ -172,7 +172,9 @@ def integrate(system,grid,Efermi=None,omega=None, Ef0=0,
     Efermi=to_array(Efermi)
     # TODO : either remove smearW from here, or remove any smearing from inside kubo. This will not allow adaptive smearing though
     if smearW is not None:
-        print( "WARNING : smearW parameteris neglected, smearing is currently done inside the kubo routine, use  kBT parameter")
+        print("WARNING : smearW parameter is neglected, smearing of frequency is currently done inside the kubo routine.\n"
+              "          To specify smearing, pass smearing parameters to the variable 'parameters' as a dict.\n"
+              "          See parameters_optical for details.")
         smearW=None
     smoothEf = getSmoother(Efermi, smearEf, "Fermi-Dirac") # smoother for functions of Fermi energy
     smoothW  = getSmoother(omega,  smearW) # smoother for functions of frequency

--- a/wannierberri/__main.py
+++ b/wannierberri/__main.py
@@ -159,7 +159,7 @@ def integrate(system,grid,Efermi=None,omega=None, Ef0=0,
 #        a single  Fermi level for optical properties
 
 
-    cprint ("\nIntegrating the following qantities: "+", ".join(quantities)+"\n",'green', attrs=['bold'])
+    cprint ("\nIntegrating the following quantities: "+", ".join(quantities)+"\n",'green', attrs=['bold'])
     check_option(quantities,integrate_options,"integrate")
     def to_array(energy):
         if energy is not None: 
@@ -227,7 +227,7 @@ def tabulate(system,grid, quantities=[],
 
     mode = '3D'
     if isinstance(grid,Path): mode = 'path'
-    cprint ("\nTabulating the following qantities: "+", ".join(quantities)+"\n",'green', attrs=['bold'])
+    cprint ("\nTabulating the following quantities: "+", ".join(quantities)+"\n",'green', attrs=['bold'])
     check_option(quantities,tabulate_options,"tabulate")
     eval_func=functools.partial(  __tabulate.tabXnk, ibands=ibands,quantities=quantities,parameters=parameters )
     t0=time()


### PR DESCRIPTION
* In `integrate`, `smearW` is imposed to be `None` (i.e. not used), but the default was `10`. I changed the default to `None`, and updated the warning that is printed if it is not `None`.
* Fixed typos: "qantities" -> "quantities", "%%" -> "%"