### PR TITLE
Add option to disable printing of K points

### DIFF
--- a/wannierberri/__evaluate.py
+++ b/wannierberri/__evaluate.py
@@ -102,7 +102,8 @@ def evaluate_K(func,system,grid,fftlib='fftw',
             fout_name="result", suffix="",
              parameters_K={},
              file_Klist="K_list.pickle",restart=False,Klist_part = 10,
-             parallel=None  # serial by default
+            parallel=None,  # serial by default
+            print_Kpoints=True,
              ):
     """This function evaluates in parallel or serial an integral over the Brillouin zone 
 of a function func, which whould receive only one argument of type Data_K, and return 
@@ -188,10 +189,11 @@ As a result, the integration will be performed over NKFFT x NKdiv
     counter=0
 
     for i_iter in range(adpt_num_iter+1):
-        print ("iteration {0} - {1} points. New points are:".format(i_iter,len([K for K in  K_list if K.res is None])) ) 
-        for i,K in enumerate(K_list):
-          if not K.evaluated:
-            print (" K-point {0} : {1} ".format(i,K))
+        if print_Kpoints:
+            print ("iteration {0} - {1} points. New points are:".format(i_iter,len([K for K in  K_list if K.res is None])) )
+            for i,K in enumerate(K_list):
+              if not K.evaluated:
+                print (" K-point {0} : {1} ".format(i,K))
         counter+=process(paralfunc,K_list,parallel,
                      symgroup=system.symgroup if  symmetrize else None,
                      remote_parameters=remote_parameters)

--- a/wannierberri/__main.py
+++ b/wannierberri/__main.py
@@ -114,6 +114,7 @@ def integrate(system,grid,Efermi=None,omega=None, Ef0=0,
                         use_irred_kpt = True, symmetrize = True,
                         fout_name="wberri",restart=False,fftlib='fftw',suffix="",file_Klist="Klist",
                         parallel = None,
+                        print_Kpoints = True,
                         parameters={},parameters_K={},specific_parameters={} ):
     """
     Integrate 
@@ -149,6 +150,8 @@ def integrate(system,grid,Efermi=None,omega=None, Ef0=0,
         evaluate only symmetry-irreducible K-points
     symmetrize : bool
         symmetrize the result (always `True` if `use_irred_kpt == True`)
+    print_Kpoints : bool
+        print the list of K points (default: True)
     parameters : dict  
         `{'name':value,...}` , Each quantity that 
         recognizes a parameter with the given name will use it
@@ -204,7 +207,8 @@ def integrate(system,grid,Efermi=None,omega=None, Ef0=0,
     res=evaluate_K(eval_func,system,grid,fftlib=fftlib,
             adpt_num_iter=adpt_num_iter,adpt_nk=adpt_fac, use_irred_kpt=use_irred_kpt,symmetrize=symmetrize,
                 fout_name=fout_name,suffix=suffix,
-                restart=restart,file_Klist=file_Klist, parallel = parallel,parameters_K=parameters_K )
+                restart=restart,file_Klist=file_Klist, parallel = parallel,parameters_K=parameters_K,
+                print_Kpoints=print_Kpoints,)
     cprint ("Integrating finished successfully",'green', attrs=['bold'])
     return res
 
@@ -215,7 +219,8 @@ def tabulate(system,grid, quantities=[], user_quantities = {},
                   use_irred_kpt = True, symmetrize = True,
                   parameters={},parameters_K={},specific_parameters={},
                   degen_thresh = 1e-4, degen_Kramers = False,
-                  parallel = None ):
+                  parallel = None,
+                  print_Kpoints = True, ):
     """
     Tabulate quantities to be plotted
 
@@ -241,6 +246,8 @@ def tabulate(system,grid, quantities=[], user_quantities = {},
         if not None, the results are also printed to text files, ready to plot by for `FermiSurfer <https://fermisurfer.osdn.jp/>`_
     parallel : :class:`~wannierberri.Parallel`
         object describing parallelization scheme
+    print_Kpoints : bool
+        print the list of K points (default: True)
     parameters : dict  
         `{'name':value,...}` , Each quantity that 
         recognizes a parameter with the given name will use it
@@ -276,7 +283,7 @@ def tabulate(system,grid, quantities=[], user_quantities = {},
     res=evaluate_K(eval_func,system,grid,
             adpt_num_iter=0 , restart=False,suffix=suffix,file_Klist=None,
             use_irred_kpt=use_irred_kpt,symmetrize=symmetrize,
-            parallel=parallel,parameters_K=parameters_K )
+            parallel=parallel,parameters_K=parameters_K, print_Kpoints=print_Kpoints )
 
     t1=time()
     if mode=='3D':

--- a/wannierberri/__main.py
+++ b/wannierberri/__main.py
@@ -151,7 +151,7 @@ def integrate(system,grid,Efermi=None,omega=None, Ef0=0,
     symmetrize : bool
         symmetrize the result (always `True` if `use_irred_kpt == True`)
     print_Kpoints : bool
-        print the list of K points (default: True)
+        print the list of K points
     parameters : dict  
         `{'name':value,...}` , Each quantity that 
         recognizes a parameter with the given name will use it
@@ -247,7 +247,7 @@ def tabulate(system,grid, quantities=[], user_quantities = {},
     parallel : :class:`~wannierberri.Parallel`
         object describing parallelization scheme
     print_Kpoints : bool
-        print the list of K points (default: True)
+        print the list of K points
     parameters : dict  
         `{'name':value,...}` , Each quantity that 
         recognizes a parameter with the given name will use it


### PR DESCRIPTION
Added `print_Kpoints` argument to `integrate` and `tabulate`. When set to `False`, the list of K points are not printed. The default is `True`.

I added this option because when I have many K points, the output becomes very long.