### PR TITLE
Add python3.9 to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
     timeout-minutes: 20
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8]
+        python-version: [3.6, 3.7, 3.8, 3.9]
         install-type: [dev]
 
     steps:


### PR DESCRIPTION
As the pyFFTW issue (#114) is fixed (on the pyFFTW side), python3.9 can be safely added to CI.

Python3.6 reached its end of life (https://endoflife.date/python), so we could remove it from CI, but I just left it because it does little (or no) harm.