### PR TITLE
Fix CI problem related to codecov and multiprocessing

### DIFF
--- a/wannierberri/__system.py
+++ b/wannierberri/__system.py
@@ -433,6 +433,8 @@ class ws_dist_map():
         param=(shifts_int_all,wannier_centers,real_lattice, ws_distance_tol, wannier_centers.shape[0])
         p=multiprocessing.Pool(npar)
         irvec_new_all=p.starmap(functools.partial(ws_dist_stars,param=param),zip(iRvec,cRvec))
+        p.close()
+        p.join()
         print('irvec_new_all shape',np.shape(irvec_new_all))
         for ir,iR in enumerate(iRvec):
           for ijw,irvec_new in irvec_new_all[ir].items():

--- a/wannierberri/__system_w90.py
+++ b/wannierberri/__system_w90.py
@@ -17,7 +17,6 @@ import copy
 import lazy_property
 import functools
 import multiprocessing 
-#from pathos.multiprocessing import ProcessingPool as Pool
 from .__utility import str2bool, alpha_A, beta_A, iterate3dpm, real_recip_lattice,fourier_q_to_R
 from colorama import init
 from termcolor import cprint 
@@ -63,6 +62,7 @@ class System_w90(System):
                     ):
 
         self.set_parameters(**parameters)
+        self.npar = npar
         self.seedname=seedname
 
         chk=CheckPoint(self.seedname)

--- a/wannierberri/__tabulate.py
+++ b/wannierberri/__tabulate.py
@@ -378,5 +378,6 @@ def _savetxt(limits=None,a=None,fmt=".8f",npar=0):
         p=multiprocessing.Pool(npar)
         res= p.map(functools.partial(_savetxt,a=a,fmt=fmt,npar=0)  , asplit)
         p.close()
+        p.join()
         return "".join(res)
 

--- a/wannierberri/__w90_files.py
+++ b/wannierberri/__w90_files.py
@@ -242,6 +242,7 @@ class MMN(W90_data):
         data=[]
         headstring=[]
         mult=4
+        # FIXME: npar = 0 does not work
         if npar>0 :
             pool=multiprocessing.Pool(npar)
         for j in range(0,NNB*NK,npar*mult):
@@ -256,6 +257,7 @@ class MMN(W90_data):
 
         if npar>0 : 
             pool.close()
+            pool.join()
         f_mmn_in.close()
         t1=time()
         data=[d[:,0]+1j*d[:,1] for d in data]


### PR DESCRIPTION
## Summary
To use `pytest-cov` with `multiprocessing.Pool`, one needs to explicitly write `pool.close()` and `pool.join()` after using a Pool. (See below if you want the details.) This was not the case in the code, so pytest with code coverage calculation hang, leading to timeout in CI. (I do not know why this problem did not appear until a few days ago, though...)

I added `pool.close()` and `pool.join()` to fix the problems. Also, it seems it is good practice to always call these two functions: https://stackoverflow.com/questions/20387510/proper-way-to-use-multiprocessor-pool-in-a-nested-loop.

I have one question: is the function `pool` in `__parallel.py` still needed? If we only need `pool(0)` case, then we can remove or simplify it. There is this line with `pool(npar_k)` https://github.com/wannier-berri/wannier-berri/blob/9cc67e7b505a4617de8ccd970ebb7831580060ad/wannierberri/__parallel.py#L69 but do we really need to instantiate a `Pool` even when using ray?


## Details of the problem
The pytest-cov doc says
https://pytest-cov.readthedocs.io/en/latest/subprocess-support.html?highlight=multiprocessing#if-you-use-multiprocessing-pool

> If you use multiprocessing.Pool.terminate or the context manager API (__exit__ will just call terminate) then the workers can get SIGTERM and then the finalizers won’t run or complete in time. Thus you need to make sure your multiprocessing.Pool gets a nice and clean exit:

(Here, "context manager API" means `with multiprocessing.Pool(npar) as pool:`.)

### A simple reproducer:
Create `test_mp.py`:
```python3
import multiprocessing as mp
def f(x):
    return x**2
def test_mp():
    pool = mp.Pool(mp.cpu_count())
    print(pool.map(f, range(10)))
    pool.close()
    # pool.join()
```
and run `python3 -m pytest --cov=./ --cov-report=xml -v --capture=tee-sys test_mp.py` a few times. Then, pytest will hang. If you uncomment `pool.join()`, the problem disappears.
