### PR TITLE
Automatic symmetry detection using spglib

### DIFF
--- a/.github/install_script.sh
+++ b/.github/install_script.sh
@@ -9,6 +9,9 @@ set -ev
 pip install codecov
 pip install -U pip setuptools wheel
 
+# install optional dependencies
+pip install tbmodels, pythtb, spglib
+
 case "$INSTALL_TYPE" in
     dev)
         pip install -e .

--- a/.github/install_script.sh
+++ b/.github/install_script.sh
@@ -10,7 +10,7 @@ pip install codecov
 pip install -U pip setuptools wheel
 
 # install optional dependencies
-pip install tbmodels, pythtb, spglib
+pip install tbmodels pythtb spglib
 
 case "$INSTALL_TYPE" in
     dev)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,8 +24,6 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install pytest
-        pip install tbmodels
-        pip install pythtb
     - name: Install the python project
       env:
         INSTALL_TYPE: ${{ matrix.install-type }}

--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -20,8 +20,6 @@ jobs:
         python -m pip install --upgrade pip
         pip install pytest
         pip install pytest-cov
-        pip install tbmodels
-        pip install pythtb
     - name: Install the python project
       env:
         INSTALL_TYPE: dev

--- a/tests/common_systems.py
+++ b/tests/common_systems.py
@@ -13,7 +13,7 @@ from wannierberri import models as wb_models
 from common import ROOT_DIR
 
 symmetries_Fe = [SYM.C4z, SYM.C2x * SYM.TimeReversal, SYM.Inversion]
-symmetries_GaAs = [SYM.C4z, SYM.TimeReversal, SYM.Rotation(3, [1,1,1])]
+symmetries_GaAs = [SYM.C4z * SYM.Inversion, SYM.TimeReversal, SYM.Rotation(3, [1,1,1])]
 
 Efermi_Fe = np.linspace(17, 18, 11)
 Efermi_Fe_FPLO = np.linspace(-0.5, 0.5, 11)

--- a/tests/test_symmetry.py
+++ b/tests/test_symmetry.py
@@ -36,8 +36,8 @@ def test_symmetry_spglib_GaAs(system_GaAs_W90, check_symgroup_equal):
 
     system_spglib = deepcopy(system_GaAs_W90)
     positions = [[0., 0., 0.], [0.25, 0.25, 0.25]]
-    numbers = [1, 2]
-    system_spglib.set_structure(positions, numbers)
+    labels = ["Ga", "As"]
+    system_spglib.set_structure(positions, labels)
     system_spglib.set_symmetry_from_structure()
 
     check_symgroup_equal(system_explicit.symgroup, system_spglib.symgroup)
@@ -52,9 +52,13 @@ def test_symmetry_spglib_Fe(system_Fe_W90, check_symgroup_equal):
 
     system_spglib = deepcopy(system_Fe_W90)
     positions = [[0., 0., 0.]]
-    numbers = [1]
+    labels = ["Fe"]
     magnetic_moments = [[0., 0., 1.]]
-    system_spglib.set_structure(positions, numbers, magnetic_moments)
+    system_spglib.set_structure(positions, labels, magnetic_moments)
     system_spglib.set_symmetry_from_structure()
 
     check_symgroup_equal(system_explicit.symgroup, system_spglib.symgroup)
+
+    # Raise error if magnetic_moments is set to a number, not a 3d vector
+    with pytest.raises(Exception):
+        system_spglib.set_structure(positions, labels, [1.])

--- a/tests/test_symmetry.py
+++ b/tests/test_symmetry.py
@@ -1,10 +1,22 @@
 """Test symmetry objects"""
 
+from copy import deepcopy
 import numpy as np
 import pytest
 
 import wannierberri as wberri
 import wannierberri.symmetry as sym
+
+from common_systems import symmetries_GaAs
+
+@pytest.fixture
+def check_symgroup_equal():
+    def _inner(g1, g2):
+        assert g1.size == g2.size, "Symmetry group size is different"
+        for sym in g1.symmetries:
+            if sym not in g2.symmetries:
+                assert False, f"Symmetry {sym} in group 1 is not in group 2"
+    return _inner
 
 def test_symmetry_group():
     assert sym.Group([sym.Inversion, sym.TimeReversal]).size == 4
@@ -17,3 +29,15 @@ def test_symmetry_group_failure():
         c = np.cos(0.1)
         s = np.sin(0.1)
         y = sym.Group([sym.Symmetry(np.array([[1, 0, 0], [0, c, s], [0, -s, c]]))])
+
+def test_symmetry_spglib(system_GaAs_W90, check_symgroup_equal):
+    system_explicit = deepcopy(system_GaAs_W90)
+    system_explicit.set_symmetry(symmetries_GaAs)
+
+    system_spglib = deepcopy(system_GaAs_W90)
+    positions = [[0., 0., 0.], [0.25, 0.25, 0.25]]
+    numbers = [1, 2]
+    system_spglib.set_structure(positions, numbers)
+    system_spglib.set_symmetry_from_structure()
+
+    check_symgroup_equal(system_explicit.symgroup, system_spglib.symgroup)

--- a/tests/test_symmetry.py
+++ b/tests/test_symmetry.py
@@ -1,0 +1,19 @@
+"""Test symmetry objects"""
+
+import numpy as np
+import pytest
+
+import wannierberri as wberri
+import wannierberri.symmetry as sym
+
+def test_symmetry_group():
+    assert sym.Group([sym.Inversion, sym.TimeReversal]).size == 4
+    assert sym.Group([sym.C3z, sym.C6z]).size == 6
+    assert sym.Group([sym.Inversion, sym.C4z, sym.TimeReversal*sym.C2x]).size == 16
+
+def test_symmetry_group_failure():
+    # sym.Group should fail for this generator
+    with pytest.raises(RuntimeError):
+        c = np.cos(0.1)
+        s = np.sin(0.1)
+        y = sym.Group([sym.Symmetry(np.array([[1, 0, 0], [0, c, s], [0, -s, c]]))])

--- a/tests/test_symmetry.py
+++ b/tests/test_symmetry.py
@@ -7,7 +7,7 @@ import pytest
 import wannierberri as wberri
 import wannierberri.symmetry as sym
 
-from common_systems import symmetries_GaAs
+from common_systems import symmetries_GaAs, symmetries_Fe
 
 @pytest.fixture
 def check_symgroup_equal():
@@ -30,7 +30,7 @@ def test_symmetry_group_failure():
         s = np.sin(0.1)
         y = sym.Group([sym.Symmetry(np.array([[1, 0, 0], [0, c, s], [0, -s, c]]))])
 
-def test_symmetry_spglib(system_GaAs_W90, check_symgroup_equal):
+def test_symmetry_spglib_GaAs(system_GaAs_W90, check_symgroup_equal):
     system_explicit = deepcopy(system_GaAs_W90)
     system_explicit.set_symmetry(symmetries_GaAs)
 
@@ -38,6 +38,23 @@ def test_symmetry_spglib(system_GaAs_W90, check_symgroup_equal):
     positions = [[0., 0., 0.], [0.25, 0.25, 0.25]]
     numbers = [1, 2]
     system_spglib.set_structure(positions, numbers)
+    system_spglib.set_symmetry_from_structure()
+
+    check_symgroup_equal(system_explicit.symgroup, system_spglib.symgroup)
+
+def test_symmetry_spglib_Fe(system_Fe_W90, check_symgroup_equal):
+    system_explicit = deepcopy(system_Fe_W90)
+
+    # Magnetic symmetries involving time-reversal is not implemented in spglib.
+    # So, we exclude symmetries involving time reversal from the generators.
+    symmetries_Fe_except_TR = [sym for sym in symmetries_Fe if not sym.TR]
+    system_explicit.set_symmetry(symmetries_Fe_except_TR)
+
+    system_spglib = deepcopy(system_Fe_W90)
+    positions = [[0., 0., 0.]]
+    numbers = [1]
+    magnetic_moments = [[0., 0., 1.]]
+    system_spglib.set_structure(positions, numbers, magnetic_moments)
     system_spglib.set_symmetry_from_structure()
 
     check_symgroup_equal(system_explicit.symgroup, system_spglib.symgroup)

--- a/wannierberri/__system.py
+++ b/wannierberri/__system.py
@@ -444,12 +444,11 @@ class System():
         """
         Set the symmetry group of the :class:`System`. Requires spglib to be installed.
         :meth:`System.set_structure` must be called in advance.
+
+        For magnetic systems, symmetries involving time reversal are not detected because
+        spglib does not support time reversal symmetry for noncollinear systems.
         """
         import spglib
-        if self.magnetic_moments is not None:
-            # Magnetic symmetry not implemented
-            # https://github.com/spglib/spglib/issues/150
-            raise NotImplementedError
 
         spglib_symmetry = spglib.get_symmetry(self.get_spglib_cell())
         symmetry_gen = []
@@ -460,13 +459,13 @@ class System():
             W = spglib_symmetry["rotations"][isym]
             Wcart = self.real_lattice.T @ W @ np.linalg.inv(self.real_lattice).T
             R = Wcart.T
-            # TODO: Time reversal information
             symmetry_gen.append(Symmetry(R))
 
         if self.magnetic_moments is None:
             symmetry_gen.append(TimeReversal)
         else:
-            print("Warning: spglib does not ")
+            print("Warning: spglib does not support time reversal symmetry for noncollinear "
+                  "systems.\nTo include such symmetries, use set_symmetry.")
 
         self.symgroup = Group(symmetry_gen, recip_lattice=self.recip_lattice, real_lattice=self.real_lattice)
 

--- a/wannierberri/__system.py
+++ b/wannierberri/__system.py
@@ -45,7 +45,7 @@ class System():
 
     __doc__ = """
     The base class for describing a system. Does not have its own constructor, 
-    please use the child classes, e.g  :class:`~wannierberri.System_w90` or :class:`~wannierberri.System_tb`
+    please use the child classes, e.g  :class:`System_w90` or :class:`System_tb`
 
 
     Parameters
@@ -70,9 +70,9 @@ class System():
         minimal distance replica selection method :ref:`sec-replica`.  equivalent of ``use_ws_distance`` in Wannier90. Default: ``{use_ws}``
     mp_grid : [nk1,nk2,nk3]
         size of Monkhorst-Pack frid used in ab initio calculation. Needed when `use_ws=True`, and only if it cannot be read from input file, i.e.
-        like :class:`~wannierberri.System_tb`, :class:`~wannierberri.System_PythTB`, :class:`~wannierberri.System_TBmodels` ,:class:`~wannierberri.System_fplo`, but only if 
+        like :class:`.System_tb`, :class:`.System_PythTB`, :class:`.System_TBmodels` ,:class:`.System_fplo`, but only if
         the data originate from ab initio data, not from toy models.
-        In contrast, for :class:`~wannierberri.System_w90` and :class:`~wannierberri.System_ase` it is not needed,  but can be provided and will override the original value 
+        In contrast, for :class:`.System_w90` and :class:`.System_ase` it is not needed,  but can be provided and will override the original value
         (if you know what and why you are doing)
         Default: ``{mp_grid}``
     frozen_max : float
@@ -248,19 +248,19 @@ class System():
 
     def set_symmetry(self,symmetry_gen=[]):
         """ 
-        Set the symmetry group of the :class:`~wannierberri.__system.System` 
+        Set the symmetry group of the :class:`System`
 
         Parameters
         ----------
-        symmetry_gen : list of :class:`~wannierberri.symmetry.Symmetry` or str
-            The generators of the symmetry group. 
+        symmetry_gen : list of :class:`symmetry.Symmetry` or str
+            The generators of the symmetry group.
 
         Notes
         -----
         + Only the generators of the symmetry group are essential. However, no problem if more symmetries are provided. 
           The code further evaluates all possible products of symmetry operations, until the full group is restored.
         + Providing `Identity` is not needed. It is included by default
-        + Operations are given as objects of class:`~wannierberri.Symmetry.symmetry` or by name as `str`, e.g. ``'Inversion'`` , ``'C6z'``, or products like ``'TimeReversal*C2x'``.
+        + Operations are given as objects of :class:`symmetry.Symmetry` or by name as `str`, e.g. ``'Inversion'`` , ``'C6z'``, or products like ``'TimeReversal*C2x'``.
         + ``symetyry_gen=[]`` is equivalent to not calling this function at all
         + Only the **point group** operations are important. Hence, for non-symmorphic operations, only the rotational part should be given, neglecting the translation.
 

--- a/wannierberri/__system.py
+++ b/wannierberri/__system.py
@@ -446,6 +446,11 @@ class System():
         :meth:`System.set_structure` must be called in advance.
         """
         import spglib
+        if self.magnetic_moments is not None:
+            # Magnetic symmetry not implemented
+            # https://github.com/spglib/spglib/issues/150
+            raise NotImplementedError
+
         spglib_symmetry = spglib.get_symmetry(self.get_spglib_cell())
         symmetry_gen = []
         for isym in range(spglib_symmetry["rotations"].shape[0]):

--- a/wannierberri/symmetry.py
+++ b/wannierberri/symmetry.py
@@ -59,10 +59,17 @@ SYMMETRY_PRECISION=1e-6
 
 class Symmetry():
     """
-    Symmetries that acts on the reciprocal space objects, in Cartesian coordinates.
-    R always contains a proper rotation (det(R) = +1). The inversion is contained in
-    the variable Inv.
-    A k point transform as self.iTR * self.iInv * (sym.R @ k).
+    Symmetries that acts on reciprocal space objects, in Cartesian coordinates.
+    A k-point vector ``k`` transform as ``self.iTR * self.iInv * (sym.R @ k)``.
+
+    Attributes
+    ----------
+    R : (3, 3) ndarray
+        Proper rotation matrix. Always satisfy ``det(R) = 1``.
+    TR : bool
+        True if symmetry involves time reversal.
+    Inv : bool
+        True if symmetry involves spatial inversion.
     """
 
     def __init__(self, R, TR=False):

--- a/wannierberri/symmetry.py
+++ b/wannierberri/symmetry.py
@@ -220,28 +220,21 @@ class Group():
     def __init__(self,generator_list=[],recip_lattice=None,real_lattice=None):
         self.real_lattice,self.recip_lattice=real_recip_lattice(real_lattice=real_lattice,recip_lattice=recip_lattice)
         sym_list=[(op if isinstance(op,Symmetry) else from_string_prod(op) )    for op in generator_list  ]
-        print (sym_list)
         if len(sym_list)==0:
             sym_list=[Identity]
-        cnt=0
+
         while True:
-            cnt+=1
-            if cnt>1000:
-                raise RuntimeError("Cannot define a finite group")
-            lenold=len(sym_list)
+            lenold = len(sym_list)
             for s1 in sym_list:
-              for s2 in sym_list:
-                s3=s1*s2
-                new = True
-                for s4 in sym_list:
-                   if s3==s4:
-                      new=False
-                      break
-                if new:
-                    sym_list.append(s3)
-            lennew=len(sym_list)
-            if lenold==lennew:
+                for s2 in sym_list:
+                    s3 = s1 * s2
+                    if s3 not in sym_list:
+                        sym_list.append(s3)
+                        if len(sym_list) > 1000:
+                            raise RuntimeError("Cannot define a finite group")
+            if len(sym_list) == lenold:
                 break
+
         self.symmetries=sym_list
         MSG_not_symmetric=(" : please check if  the symmetries are consistent with the lattice vectors,"+
                     " and that  enough digits were written for the lattice vectors (at least 6-7 after coma)" )


### PR DESCRIPTION
* Added method `System.set_structure` that sets `positions`, `atom_numbers` (Integer numbers to distinguish species), and `magnetic_moments` (optional) attributes.
* Added method `System.set_symmetry_from_structure` that uses spglib to automatically detect symmetry of the system and sets the `symgroup` attribute.

Implements the first two steps of #139.

Assumes #140, #146 are merged.

Fixes #144.

For magnetic systems, symmetries involving time reversal (e.g. `SYM.C2x * SYM.TimeReversal`) are not detected because spglib does not support such symmetries. (For non-magnetic systems, TimeReversal is added to the generator so there is no problem.)

### TODO
* [x] Magnetic symmetry
* [x] Manual documentation in website? : Docstring is already generated.
* [x] More tests