### PR TITLE
Fix wrong symmetry of opt_shiftcurrent

### DIFF
--- a/tests/test_kubo.py
+++ b/tests/test_kubo.py
@@ -9,6 +9,7 @@ import wannierberri as wberri
 
 from common import OUTPUT_DIR
 from common_comparers import compare_quant
+from common_systems import symmetries_GaAs
 
 @pytest.fixture
 def check_integrate_dynamical():
@@ -70,6 +71,8 @@ def check_integrate_dynamical():
                 comparer(fout_name, quant+suffix, adpt_num_iter,
                     suffix_ref=compare_quant(quant)+suffix_ref, precision=prec, mode = mode)
         
+
+        return result
 
     return _inner
 
@@ -174,3 +177,28 @@ def test_shc(system_Fe_W90):
             f"difference of {np.max(np.abs(data_kubo - data_fermiocean))}.")
 
     # TODO: Add wcc test
+
+
+def test_shiftcurrent_symmetry(check_integrate_dynamical, system_GaAs_sym_tb):
+    """Test shift current with and without symmetry is the same for a symmetrized system"""
+    import copy
+
+    kwargs = dict(
+        quantities=["opt_shiftcurrent"],
+        Efermi=np.array([7.0]),
+        omega=np.arange(1.0, 5.1, 0.5),
+        grid_param=dict(NK=6, NKFFT=3),
+        additional_parameters=dict(smr_fixed_width=0.20, smr_type="Gaussian", sc_eta=0.1),
+        comparer=None,
+    )
+
+    system = copy.deepcopy(system_GaAs_sym_tb)
+    system.set_symmetry(symmetries_GaAs)
+
+    result_irr_k = check_integrate_dynamical(system, use_symmetry=True, fout_name="kubo_GaAs_sym_irr_k", **kwargs)
+    result_full_k = check_integrate_dynamical(system, use_symmetry=False, fout_name="kubo_GaAs_sym_full_k", **kwargs)
+
+    # FIXME: there is small but nonzero difference between the two results.
+    # It seems that the finite eta correction term (PRB 103 247101 (2021)) is needed to get perfect agreement.
+    assert result_full_k.results["opt_shiftcurrent"].data == approx(
+        result_irr_k.results["opt_shiftcurrent"].data, abs=1e-6)

--- a/wannierberri/__kubo.py
+++ b/wannierberri/__kubo.py
@@ -348,7 +348,7 @@ def opt_conductivity(data, Efermi,omega=None,  kBT=0, smr_fixed_width=0.1, smr_t
         return result.EnergyResult([Efermi,omega], tildeD*pre_fac, TRodd=False, Iodd=True, rank=rank)
 
     elif conductivity_type == 'shiftcurrent':
-        return result.EnergyResult([Efermi,omega], sigma_shift, TRodd=False, Iodd=False, rank=rank)
+        return result.EnergyResult([Efermi,omega], sigma_shift, TRodd=False, Iodd=True, rank=rank)
 
 
 def opt_SHCqiao(data, Efermi, omega=0, **parameters):


### PR DESCRIPTION
Shift current is odd under inversion, but `Iodd` was set to False. Fix this bug.

### TODO
- [x] Add test (Use symmetrized GaAs system and compare calculation w/ and w/o symmetry)