### PR TITLE
Add spglib and sympy to dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ setuptools.setup(
                         'fortio>=0.4',
                         'ray[default]',
                         'sympy',
-                        'spglib'
+                        'spglib',
                         ],
      url="https://wannier-berri.org",
      packages=setuptools.find_packages(),

--- a/setup.py
+++ b/setup.py
@@ -28,6 +28,8 @@ setuptools.setup(
                         'matplotlib',
                         'fortio>=0.4',
                         'ray[default]'
+                        'sympy',
+                        'spglib'
                         ],
      url="https://wannier-berri.org",
      packages=setuptools.find_packages(),

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ setuptools.setup(
                         'packaging>=20.8',
                         'matplotlib',
                         'fortio>=0.4',
-                        'ray[default]'
+                        'ray[default]',
                         'sympy',
                         'spglib'
                         ],


### PR DESCRIPTION
@stepan-tsirkin @Liu-Xiaoxiong @manxkim 

If I install wannierberri in a fresh environment, I get `ModuleNotFoundError: No module named 'spglib'`, and the same for `sympy`. I added them to `setup.py`.

**Since this issue blocks installation, we need to merge and release this PR before the school.**

You can test fresh installation using the following commands:
```bash
export PYTHONNOUSERSITE=True
conda create -n wbtest python=3.8.5
conda activate wbtest
pip install wannierberri
python3 -c "import wannierberri"
```
(The first line is to isolate the conda env from previously installed packages: https://stackoverflow.com/questions/35835274/how-to-reuse-global-site-packages-in-conda-env)

To install from this branch:
```bash
 pip install git+https://github.com/wannier-berri/wannier-berri.git@installation
```