### PR TITLE
Improve docstrings for smoother

### DIFF
--- a/tests/test_smoother.py
+++ b/tests/test_smoother.py
@@ -9,7 +9,7 @@ from wannierberri.smoother import (
     VoidSmoother,
     FermiDiracSmoother,
     GaussianSmoother,
-    getSmoother,
+    get_smoother,
 )
 
 
@@ -48,12 +48,12 @@ def test_smoother():
         sm_data_3d = sm(data_3d, axis=1)
         assert sm_data_3d - sm_data_1d[None, :, None] == approx(0.0, abs=1E-10)
 
-    # Test getSmoother
-    assert getSmoother(e, None) == VoidSmoother()
-    assert getSmoother(None, None) == VoidSmoother()
-    assert getSmoother([0.0], 1.0) == VoidSmoother()
-    assert getSmoother(e, 0.1, "Gaussian") == GaussianSmoother(e, 0.1)
-    assert getSmoother(e, 0.1, "Fermi-Dirac") == FermiDiracSmoother(e, 0.1)
-    assert getSmoother(e, 0.2, "Gaussian") != GaussianSmoother(e, 0.1)
-    assert getSmoother(e + 0.1, 0.2, "Gaussian") != GaussianSmoother(e, 0.1)
-    assert getSmoother(e, 0.1, "Gaussian") != FermiDiracSmoother(e, 0.1)
+    # Test get_smoother
+    assert get_smoother(e, None) == VoidSmoother()
+    assert get_smoother(None, None) == VoidSmoother()
+    assert get_smoother([0.0], 1.0) == VoidSmoother()
+    assert get_smoother(e, 0.1, "Gaussian") == GaussianSmoother(e, 0.1)
+    assert get_smoother(e, 0.1, "Fermi-Dirac") == FermiDiracSmoother(e, 0.1)
+    assert get_smoother(e, 0.2, "Gaussian") != GaussianSmoother(e, 0.1)
+    assert get_smoother(e + 0.1, 0.2, "Gaussian") != GaussianSmoother(e, 0.1)
+    assert get_smoother(e, 0.1, "Gaussian") != FermiDiracSmoother(e, 0.1)

--- a/wannierberri/__init__.py
+++ b/wannierberri/__init__.py
@@ -26,6 +26,7 @@ from .__path import Path
 from . import calculators
 from . import result
 from .parallel import Parallel, Serial
+from .smoother import get_smoother
 
 from termcolor import cprint
 

--- a/wannierberri/__old_API/__main.py
+++ b/wannierberri/__old_API/__main.py
@@ -14,7 +14,7 @@
 
 import functools
 from .__evaluate import evaluate_K
-from wannierberri.smoother import getSmoother
+from wannierberri.smoother import get_smoother
 from wannierberri.result import __tabresult
 from . import __integrate
 from . import __tabulate
@@ -206,9 +206,9 @@ def integrate(
             "          To specify smearing, pass smearing parameters to the variable 'parameters' as a dict.\n"
             "          See parameters_optical for details.")
         smearW = None
-    smoothEf = getSmoother(Efermi, smearEf, "Fermi-Dirac")  # smoother for functions of Fermi energy
-    smoothW = getSmoother(omega, smearW)  # smoother for functions of frequency
-    # smoothW  = getSmoother(omega,  smearW,  "Gaussian") # smoother for functions of frequency
+    smoothEf = get_smoother(Efermi, smearEf, "Fermi-Dirac")  # smoother for functions of Fermi energy
+    smoothW = get_smoother(omega, smearW)  # smoother for functions of frequency
+    # smoothW  = get_smoother(omega,  smearW,  "Gaussian") # smoother for functions of frequency
 
     eval_func = functools.partial(
         __integrate.intProperty,

--- a/wannierberri/smoother.py
+++ b/wannierberri/smoother.py
@@ -133,7 +133,7 @@ class VoidSmoother(AbstractSmoother):
         return A
 
 
-def getSmoother(energy, smear, mode=None):
+def get_smoother(energy, smear, mode=None):
     """
     Return a smoother that applies for the given energy range. The smoother can
     be used a function that applies to an array. The axis of the array to be smoothed
@@ -142,7 +142,7 @@ def getSmoother(energy, smear, mode=None):
     If you calculated some quantity ``data`` over a range of ``efermi`` and want
     to apply the Fermi-Dirac smoother at 300 K, run the following code::
 
-        smoother = wannierberri.getSmoother(efermi, 300, "Fermi-Dirac")
+        smoother = wannierberri.get_smoother(efermi, 300, "Fermi-Dirac")
         data_smooth = smoother(data)
 
     Parameters

--- a/wannierberri/smoother.py
+++ b/wannierberri/smoother.py
@@ -5,11 +5,8 @@ import numpy as np
 class AbstractSmoother(abc.ABC):
     """ Smoother for smoothing an array by convolution.
     This is an abstract class which cannot by instantiated. Only the specific child classes
-    can be instantiated. Each child class should implement its own version of _params,
-    __init__, and _broaden.
-    - _params : list of parameters that uniquely define the smoother.
-    - _broaden : function that defines the broadening method.
-    - __init__ : initialize Smoother parameters
+    can be instantiated. Each child class should implement its own version of ``_params``,
+    ``__init__``, and ``_broaden``.
 
     Parameters
     -----------
@@ -24,10 +21,12 @@ class AbstractSmoother(abc.ABC):
     @property
     @abc.abstractmethod
     def _params(self):
+        """list of parameters that uniquely define the smoother."""
         pass
 
     @abc.abstractmethod
     def __init__(self, E, smear, maxdE):
+        """initialize Smoother parameters"""
         self.smear = smear
         self.E = np.copy(E)
         self.maxdE = maxdE
@@ -40,6 +39,7 @@ class AbstractSmoother(abc.ABC):
 
     @abc.abstractmethod
     def _broaden(self, E):
+        """The broadening method to be used."""
         pass
 
     def __str__(self):
@@ -55,6 +55,7 @@ class AbstractSmoother(abc.ABC):
         return True
 
     def __call__(self, A, axis=0):
+        """Apply smoother to ``A`` along the given axis"""
         assert self.E.shape[0] == A.shape[axis]
         A = A.transpose((axis, ) + tuple(range(0, axis)) + tuple(range(axis + 1, A.ndim)))
         res = np.zeros(A.shape, dtype=A.dtype)
@@ -133,6 +134,30 @@ class VoidSmoother(AbstractSmoother):
 
 
 def getSmoother(energy, smear, mode=None):
+    """
+    Return a smoother that applies for the given energy range. The smoother can
+    be used a function that applies to an array. The axis of the array to be smoothed
+    can be controlled with an argument ``axis``, whose default is 0.
+
+    If you calculated some quantity ``data`` over a range of ``efermi`` and want
+    to apply the Fermi-Dirac smoother at 300 K, run the following code::
+
+        smoother = wannierberri.getSmoother(efermi, 300, "Fermi-Dirac")
+        data_smooth = smoother(data)
+
+    Parameters
+    -----------
+    energy : 1D array of float
+        The energies on which the data are calculated at. Must be evenly spaced.
+    smear : float
+        - ``mode == None``: not used.
+        - ``mode == "Fermi-Dirac"``: Smearing parameter in Kelvin units.
+        - ``mode == "Gaussian"``: Smearing parameter in eV units.
+    mode : str or None
+        Smoother mode. Default: ``None``.
+        Avaliable options: ``None``, ``"Fermi-Dirac"``, and ``"Gaussian"``.
+    """
+
     if energy is None:
         return VoidSmoother()
     if smear is None or smear <= 0:


### PR DESCRIPTION
See also https://github.com/wannier-berri/wannier-berri-org/pull/13

Also renamed function `getSmoother` to `get_smoother` to follow the python naming convention.