### PR TITLE
Solved index issue in the FPLO Hamiltonian reading function.

### DIFF
--- a/wannierberri/system/system_fplo.py
+++ b/wannierberri/system/system_fplo.py
@@ -92,7 +92,7 @@ class System_fplo(System):
                             continue
                         arread = np.array(arread, dtype=float)
                         Rvec = arread[:, :3] + (
-                            self.wannier_centers_cart_auto[None, jw] - self.wannier_centers_cart_auto[None, jw])
+                            self.wannier_centers_cart_auto[None, iw] - self.wannier_centers_cart_auto[None, jw])
                         Rvec = Rvec.dot(inv_real_lattice)  # should be integer now
                         iRvec = np.array(np.round(Rvec), dtype=int)
                         assert (abs(iRvec - Rvec).max() < 1e-8)


### PR DESCRIPTION
One of the used indices seems to be false, the calculated distance vector (R_vec) is in turn not an integer linear combination of the Bravais vectors. This results in an assert error in line 98.
My corrent choice (iw,jw) reproduced the correct band structure.