### PR TITLE
fixed spglib<2

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ setuptools.setup(
                         'protobuf==3.20.1', # req by ray : https://github.com/ray-project/ray/issues/25205 , https://developers.google.com/protocol-buffers/docs/news/2022-05-06#python-updates
                         'ray[default]',
                         'sympy',
-                        'spglib',
+                        'spglib<2',
                         ],
      url="https://wannier-berri.org",
      packages=setuptools.find_packages(),


### PR DESCRIPTION
At the moment the new `spglib-2.0,x` give errors 

```
FAILED tests/test_symmetry.py::test_symmetry_spglib_Fe - AssertionError: Symmetry group size is different
```
So far let's stick to spglib<2 . Should we set a lower bound?

@Liu-Xiaoxiong , please take a note for later to figure out what they changed and how to make it compatible