### PR TITLE
Fix an edge case in DynamicCalculator

### DIFF
--- a/tests/test_run.py
+++ b/tests/test_run.py
@@ -239,6 +239,26 @@ def test_Fe(check_run, system_Fe_W90, compare_any_result, compare_fermisurfer):
                 precision=prec)
 
 
+def test_Fe_dynamic_noband(check_run, system_Fe_W90, compare_any_result):
+    param = {'Efermi': Efermi_Fe}
+    param_tab = {'degen_thresh': 5e-2}
+    calculators = {}
+    parameters_optical = dict(
+        Efermi=np.array([117.0, 118.0]), omega=np.arange(0.0, 7.1, 1.0), smr_fixed_width=0.20, smr_type="Gaussian")
+
+    calculators['opt_conductivity'] = wberri.calculators.dynamic.OpticalConductivity(**parameters_optical)
+    calculators['opt_SHCqiao'] = wberri.calculators.dynamic.SHC(SHC_type="qiao", **parameters_optical)
+    calculators['opt_SHCryoo'] = wberri.calculators.dynamic.SHC(SHC_type="ryoo", **parameters_optical)
+
+    result = check_run(
+        system_Fe_W90,
+        calculators,
+        fout_name="berry_Fe_W90",
+        suffix="run_noband",
+        precision = 1e-15,
+        compare_zero = True)
+
+
 def test_Fe_wcc(check_run, system_Fe_W90_wcc, compare_any_result):
     param_kwargs = {'Efermi': Efermi_Fe, 'kwargs_formula':{'correction_wcc': True}}
     param = {'Efermi': Efermi_Fe}

--- a/tests/test_run.py
+++ b/tests/test_run.py
@@ -240,8 +240,6 @@ def test_Fe(check_run, system_Fe_W90, compare_any_result, compare_fermisurfer):
 
 
 def test_Fe_dynamic_noband(check_run, system_Fe_W90, compare_any_result):
-    param = {'Efermi': Efermi_Fe}
-    param_tab = {'degen_thresh': 5e-2}
     calculators = {}
     parameters_optical = dict(
         Efermi=np.array([117.0, 118.0]), omega=np.arange(0.0, 7.1, 1.0), smr_fixed_width=0.20, smr_type="Gaussian")
@@ -250,13 +248,13 @@ def test_Fe_dynamic_noband(check_run, system_Fe_W90, compare_any_result):
     calculators['opt_SHCqiao'] = wberri.calculators.dynamic.SHC(SHC_type="qiao", **parameters_optical)
     calculators['opt_SHCryoo'] = wberri.calculators.dynamic.SHC(SHC_type="ryoo", **parameters_optical)
 
-    result = check_run(
+    check_run(
         system_Fe_W90,
         calculators,
         fout_name="berry_Fe_W90",
         suffix="run_noband",
-        precision = 1e-15,
-        compare_zero = True)
+        precision=1e-15,
+        compare_zero=True)
 
 
 def test_Fe_wcc(check_run, system_Fe_W90_wcc, compare_any_result):

--- a/wannierberri/calculators/dynamic.py
+++ b/wannierberri/calculators/dynamic.py
@@ -72,6 +72,9 @@ class DynamicCalculator(Calculator, abc.ABC):
                 if self.nonzero(Em, En)
             ]
             npair = len(degen_group_pairs)
+            if npair == 0:
+                continue
+
             matrix_elements = np.array(
                 [formula.trace_ln(ik, np.arange(*pair[0]), np.arange(*pair[1])) for pair in degen_group_pairs])
             factor_Efermi = np.array([self.factor_Efermi(pair[2], pair[3]) for pair in degen_group_pairs])


### PR DESCRIPTION
In class `DynamicCalculator`, if the Fermi level is far too lower (or too higher) than energy bands so that every band is unoccupied (or occupied), then `npair == 0` and the subsequent matrix calculations emit an error because the sizes of relevant arrays are zero.

This PR fixes this bug.