### PR TITLE
fixed the tetrahedron method to be more accurate with der=0

### DIFF
--- a/tests/test_tetra.py
+++ b/tests/test_tetra.py
@@ -81,16 +81,16 @@ data2e = (5.934   , 5.93314105, 5.93327453, 5.93327816, 5.93373734, 1.0, 1.0)
 data3 = ( 0.34253665432,0.121245,0.2356431,0.51254,0.614651,0.38891045,0.38891045)
 
 
-@pytest.mark.parametrize("data",[data1,data2,data2b,data2c,data2d,data2e,data2,data3])
+@pytest.mark.parametrize("data", [data1,data2,data2b,data2c,data2d,data2e,data2,data3])
 def test_tetra_accurate(data):
     """testing some 'magic' values, for which the old implementation gives errors
         aso some normal inpyuts are checked
         data is (ef,e1,e2,e3,e4,w_old,w_acc)
     """
-    ef,e1,e2,e3,e4=data[:5]
-    ef=np.array([ef])
-    weight_old=weights_tetra(ef,e1,e2,e3,e4,der=0,accurate=False)
-    weight_acc=weights_tetra(ef,e1,e2,e3,e4,der=0,accurate=True)
+    ef,e1,e2,e3,e4 = data[:5]
+    ef = np.array([ef])
+    weight_old = weights_tetra(ef,e1,e2,e3,e4,der=0,accurate=False)
+    weight_acc = weights_tetra(ef,e1,e2,e3,e4,der=0,accurate=True)
     print ("weights (old/acc):",weight_old,weight_acc)
     assert weight_old[0] == approx(data[5],abs=1e-8)
-    assert weight_acc[0] == approx(data[6],abs=1e-8) 
+    assert weight_acc[0] == approx(data[6],abs=1e-8)

--- a/tests/test_tetra.py
+++ b/tests/test_tetra.py
@@ -1,5 +1,6 @@
 import numpy as np
 from wannierberri.__tetrahedron import weights_tetra
+import pytest
 from pytest import approx
 
 
@@ -69,3 +70,27 @@ def test_tetra_derivatives():
         ])
     for e in E:
         check_tetra_derivatives(E=e)
+
+
+data1 = (5.7337,    5.73353853088151321771,    5.73363955524649249185,    5.73396963801047121478,    5.74032502121022680797, -0.01272583,0.01325275 )
+data2 = (5.933275 , 5.93314105, 5.93327453, 5.93327816, 5.93373734, 0.5      , 0.22023401)
+data2b = (5.933274, 5.93314105, 5.93327453, 5.93327816, 5.93373734, 0.2265625, 0.21533874)
+data2c = (5.933200, 5.93314105, 5.93327453, 5.93327816, 5.93373734, 0.02734375, 0.01877191)
+data2d = (5.933   , 5.93314105, 5.93327453, 5.93327816, 5.93373734, 0.0, 0.0)
+data2e = (5.934   , 5.93314105, 5.93327453, 5.93327816, 5.93373734, 1.0, 1.0)
+data3 = ( 0.34253665432,0.121245,0.2356431,0.51254,0.614651,0.38891045,0.38891045)
+
+
+@pytest.mark.parametrize("data",[data1,data2,data2b,data2c,data2d,data2e,data2,data3])
+def test_tetra_accurate(data):
+    """testing some 'magic' values, for which the old implementation gives errors
+        aso some normal inpyuts are checked
+        data is (ef,e1,e2,e3,e4,w_old,w_acc)
+    """
+    ef,e1,e2,e3,e4=data[:5]
+    ef=np.array([ef])
+    weight_old=weights_tetra(ef,e1,e2,e3,e4,der=0,accurate=False)
+    weight_acc=weights_tetra(ef,e1,e2,e3,e4,der=0,accurate=True)
+    print ("weights (old/acc):",weight_old,weight_acc)
+    assert weight_old[0] == approx(data[5],abs=1e-8)
+    assert weight_acc[0] == approx(data[6],abs=1e-8) 

--- a/wannierberri/__tetrahedron.py
+++ b/wannierberri/__tetrahedron.py
@@ -23,7 +23,7 @@ def weights_tetra(efall, e0, e1, e2, e3, der=0, accurate=True):
     # a dirty trick to avoid divisions by zero
     diff_min=1e-12
     for i in range(3):
-        if abs(e[i + 1] - e[i]) < diff_min:
+        if e[i + 1] - e[i] < diff_min:
             e[i + 1] = e[i] + diff_min
     e1, e2, e3, e4 = e
 

--- a/wannierberri/__tetrahedron.py
+++ b/wannierberri/__tetrahedron.py
@@ -15,23 +15,47 @@ from numba import njit
 
 
 @njit
-def weights_tetra(efall, e0, e1, e2, e3, der=0):
-
+def weights_tetra(efall, e0, e1, e2, e3, der=0, accurate=True):
     e = [e0, e1, e2, e3]
 
     #    print (e0,e1,e2,e3,der)
     e = np.array(sorted([e0, e1, e2, e3]))
     # a dirty trick to avoid divisions by zero
+    diff_min=1e-12
     for i in range(3):
-        if abs(e[i + 1] - e[i]) < 1e-12:
-            e[i + 1:] += 1e-10
+        if abs(e[i + 1] - e[i]) < diff_min:
+            e[i + 1] = e[i] + diff_min
     e1, e2, e3, e4 = e
 
     nEF = len(efall)
     occ = np.zeros((nEF))
+
+    # the accurate behaviour is a bit slower, but in some cases the faster implementation gives wrong results
+    # in particular, when the energies e0,e1,e2,e3 are close to each other
+    # TODO : check how to handle this with derivatives
+    if accurate and der==0:
+        for i in range(nEF):
+            ef = efall[i]
+            if ef >= e4:
+                occ[i] = 1.
+            elif ef < e1:
+                occ[i] = 0.
+            elif ef >= e3:  # c3
+                occ[i] = 1 - ((ef-e4)/(e1-e4)) * ((ef-e4)/(e2-e4)) * ((ef-e4)/(e3-e4))
+            elif ef >= e2:  # c2
+                a13 = (ef-e1)/(e3-e1)
+                a14 = (ef-e1)/(e4-e1)
+                a23 = (ef-e2)/(e3-e2)
+                a24 = (ef-e2)/(e4-e2)
+                occ[i] = a23*a24 + a13*( a14*(1-a24) + a24*(1-a23) )
+            else:  # c1
+                occ[i] = ((ef-e1)/(e2-e1)) * ((ef-e1)/(e3-e1)) * ((ef-e1)/(e4-e1))
+        return occ
+
     denom3 = 1. / ((e4 - e1) * (e4 - e2) * (e4 - e3))
     denom2 = 1. / ((e3 - e1) * (e4 - e1) * (e3 - e2) * (e4 - e2))
     denom1 = 1. / ((e2 - e1) * (e3 - e1) * (e4 - e1))
+#    _denom1 = 1. / ((e2 - e1) * (e3 - e1) * (e4 - e1))
 
     if der == 0:
         c10 = -e1**3 * denom1
@@ -105,6 +129,7 @@ def weights_tetra(efall, e0, e1, e2, e3, der=0):
             else:  # c1
                 occ[i] = 6 * c13
     return occ
+
 
 
 #@njit


### PR DESCRIPTION
I noticed some weird behaviour of tetrahedron method in some cases,.
Basically, the origin is that in numerics it matters in what order to perform arithmetic operations. 
The problem arises only for specific values of the energies in tetrahedron, in particular those that are close to each other. 

I fixed that for `der=0`, in future we need to check also for derivatives.