### PR TITLE
fixed a bug for tetrahedron method

### DIFF
--- a/wannierberri/__tetrahedron.py
+++ b/wannierberri/__tetrahedron.py
@@ -148,7 +148,7 @@ def get_bands_in_range(emin, emax, Eband, degen_thresh=-1, degen_Kramers=False, 
         Ebandmax = Eband
     bands = []
     for ib1, ib2 in get_borders(Eband, degen_thresh, degen_Kramers=degen_Kramers):
-        if Ebandmax[ib1:ib2].max() >= emin and Ebandmax[ib1:ib2].min() <= emax:
+        if Ebandmax[ib1:ib2].max() >= emin and Ebandmin[ib1:ib2].min() <= emax:
             bands.append([ib1, ib2])
     return bands
 


### PR DESCRIPTION
A small bug, but it made the result dependent on the range of Fermi levels used. 
Say, if we extend the array of Fermi levels, the result for the old Fermi levels should stay the same, but it was not the case. Now fixed. 

Also extended the Chiral test (this extension fails with old version)