### PR TITLE
Order bk vectors consistently for all k-points

### DIFF
--- a/tests/test_formatted.py
+++ b/tests/test_formatted.py
@@ -61,12 +61,12 @@ def generate_formatted_files(create_files_GaAs_W90):
 
 def test_formatted_uXu(generate_formatted_files):
     data_dir = generate_formatted_files
-    uHu_unformatted = UHU(os.path.join(data_dir, "GaAs"))
-    uHu_formatted = UHU(os.path.join(data_dir, "GaAs_formatted"), formatted=True)
+    uHu_unformatted = UHU(os.path.join(data_dir, "GaAs"), reorder_bk="do not reorder")
+    uHu_formatted = UHU(os.path.join(data_dir, "GaAs_formatted"), formatted=True, reorder_bk="do not reorder")
     assert np.allclose(uHu_unformatted.data, uHu_formatted.data)
 
-    uIu_unformatted = UIU(os.path.join(data_dir, "GaAs"))
-    uIu_formatted = UIU(os.path.join(data_dir, "GaAs_formatted"), formatted=True)
+    uIu_unformatted = UIU(os.path.join(data_dir, "GaAs"), reorder_bk="do not reorder")
+    uIu_formatted = UIU(os.path.join(data_dir, "GaAs_formatted"), formatted=True, reorder_bk="do not reorder")
     assert np.allclose(uIu_unformatted.data, uIu_formatted.data)
 
 
@@ -79,10 +79,10 @@ def test_formatted_spn(generate_formatted_files):
 
 def test_formatted_sXu(generate_formatted_files):
     data_dir = generate_formatted_files
-    sHu_unformatted = SHU(os.path.join(data_dir, "GaAs"))
-    sHu_formatted = SHU(os.path.join(data_dir, "GaAs_formatted"), formatted=True)
+    sHu_unformatted = SHU(os.path.join(data_dir, "GaAs"), reorder_bk="do not reorder")
+    sHu_formatted = SHU(os.path.join(data_dir, "GaAs_formatted"), formatted=True, reorder_bk="do not reorder")
     assert np.allclose(sHu_unformatted.data, sHu_formatted.data)
 
-    sIu_unformatted = SIU(os.path.join(data_dir, "GaAs"))
-    sIu_formatted = SIU(os.path.join(data_dir, "GaAs_formatted"), formatted=True)
+    sIu_unformatted = SIU(os.path.join(data_dir, "GaAs"), reorder_bk="do not reorder")
+    sIu_formatted = SIU(os.path.join(data_dir, "GaAs_formatted"), formatted=True, reorder_bk="do not reorder")
     assert np.allclose(sIu_unformatted.data, sIu_formatted.data)

--- a/wannierberri/system/system_w90.py
+++ b/wannierberri/system/system_w90.py
@@ -204,7 +204,7 @@ class System_w90(System_R):
         # Wannier centers
         centers = chk.wannier_centers
         # Unique set of nearest-neighbor vectors (cartesian)
-        bk_cart_unique = w90data.mmn.bk_cart_unique
+        bk_cart = w90data.mmn.bk_cart
 
         if use_wcc_phase_findiff or transl_inv_JM:  # Phase convention I
             if use_wcc_phase_findiff:
@@ -213,7 +213,7 @@ class System_w90(System_R):
             elif transl_inv_JM:
                 _r0 = 0.5 * (centers[:, None, :] + centers[None, :, :])
                 sum_b = False
-            expjphase1 = np.exp(1j * np.einsum('ba,ija->ijb', bk_cart_unique, _r0))
+            expjphase1 = np.exp(1j * np.einsum('ba,ija->ijb', bk_cart, _r0))
             print(f"expjphase1 {expjphase1.shape}")
             expjphase2 = expjphase1.swapaxes(0, 1).conj()[:, :, :, None] * expjphase1[:, :, None, :]
         else:
@@ -297,7 +297,7 @@ class System_w90(System_R):
             self.do_ws_dist(mp_grid=mp_grid)
 
         if transl_inv_JM:
-            self.recenter_JM(centers, bk_cart_unique)
+            self.recenter_JM(centers, bk_cart)
 
         self.do_at_end_of_init()
         if (not transl_inv_JM) and self.use_wcc_phase and (not wcc_phase_fin_diff):

--- a/wannierberri/w90files/chk.py
+++ b/wannierberri/w90files/chk.py
@@ -182,24 +182,24 @@ class CheckPoint:
         for ik in range(self.num_kpts):
             for ib in range(mmn.NNB):
                 iknb = mmn.neighbours[ik, ib]
-                ib_unique = mmn.ib_unique_map[ik, ib]
                 # Matrix < u_k | u_k+b > (mmn)
                 data = mmn.data[ik, ib]                   # Hamiltonian gauge
                 if eig is not None:
                     data = data * eig.data[ik, :, None]  # Hamiltonian gauge (add energies)
                 AAW = self.wannier_gauge(data, ik, iknb)  # Wannier gauge
                 # Matrix for finite-difference schemes
-                AA_q_ik_ib = 1.j * AAW[:, :, None] * mmn.wk[ik, ib] * mmn.bk_cart[ik, ib, None, None, :]
+                AA_q_ik_ib = 1.j * AAW[:, :, None] * mmn.wk[ib] * mmn.bk_cart[ib, None, None, :]
                 # Marzari & Vanderbilt formula for band-diagonal matrix elements
                 if transl_inv:
                     AA_q_ik_ib[range(self.num_wann), range(self.num_wann)] = -np.log(
-                        AAW.diagonal()).imag[:, None] * mmn.wk[ik, ib] * mmn.bk_cart[ik, ib, None, :]
+                        AAW.diagonal()).imag[:, None] * mmn.wk[ib] * mmn.bk_cart[ib, None, :]
                 if phase is not None:
-                    AA_q_ik_ib *= phase[:, :, ib_unique, None]
+                    # print (f"AA_q_ik_ib.shape={AA_q_ik_ib.shape}, phase.shape={phase.shape}")
+                    AA_q_ik_ib *= phase[:, :, ib, None]
                 if sum_b:
                     AA_qb[ik] += AA_q_ik_ib
                 else:
-                    AA_qb[ik, :, :, ib_unique, :] = AA_q_ik_ib
+                    AA_qb[ik, :, :, ib, :] = AA_q_ik_ib
         return AA_qb
 
 
@@ -248,9 +248,9 @@ class CheckPoint:
                 mmn_loc = self.wannier_gauge(mmn.data[ik, ib], ik, iknb)
                 mmn_loc = mmn_loc.diagonal()
                 log_loc = np.angle(mmn_loc)
-                wcc += -log_loc[:, None] * mmn.wk[ik, ib] * mmn.bk_cart[ik, ib]
+                wcc += -log_loc[:, None] * mmn.wk[ib] * mmn.bk_cart[ib]
                 if spreads:
-                    r2 += (1 - np.abs(mmn_loc) ** 2 + log_loc ** 2) * mmn.wk[ik, ib]
+                    r2 += (1 - np.abs(mmn_loc) ** 2 + log_loc ** 2) * mmn.wk[ib]
         wcc /= mmn.NK
         if spreads:
             return wcc, r2 / mmn.NK - np.sum(wcc**2, axis=1)
@@ -301,10 +301,8 @@ class CheckPoint:
         for ik in range(self.num_kpts):
             for ib1 in range(mmn.NNB):
                 iknb1 = mmn.neighbours[ik, ib1]
-                ib1_unique = mmn.ib_unique_map[ik, ib1]
                 for ib2 in range(mmn.NNB):
                     iknb2 = mmn.neighbours[ik, ib2]
-                    ib2_unique = mmn.ib_unique_map[ik, ib2]
 
                     # Matrix < u_k+b1 | H_k | u_k+b2 > (uHu)
                     data = uhu.data[ik, ib1, ib2]                 # Hamiltonian gauge
@@ -313,21 +311,21 @@ class CheckPoint:
                     if antisym:
                         # Matrix for finite-difference schemes (takes antisymmetric piece only)
                         CC_q_ik_ib = 1.j * CCW[:, :, None] * (
-                            mmn.wk[ik, ib1] * mmn.wk[ik, ib2] * (
-                                mmn.bk_cart[ik, ib1, alpha_A] * mmn.bk_cart[ik, ib2, beta_A] -
-                                mmn.bk_cart[ik, ib1, beta_A] * mmn.bk_cart[ik, ib2, alpha_A]))[None, None, :]
+                            mmn.wk[ib1] * mmn.wk[ib2] * (
+                                mmn.bk_cart[ib1, alpha_A] * mmn.bk_cart[ib2, beta_A] -
+                                mmn.bk_cart[ib1, beta_A] * mmn.bk_cart[ib2, alpha_A]))[None, None, :]
                     else:
                         # Matrix for finite-difference schemes (takes symmetric piece only)
                         CC_q_ik_ib = CCW[:, :, None, None] * (
-                            mmn.wk[ik, ib1] * mmn.wk[ik, ib2] * (
-                                mmn.bk_cart[ik, ib1, :, None] *
-                                mmn.bk_cart[ik, ib2, None, :]))[None, None, :, :]
+                            mmn.wk[ib1] * mmn.wk[ib2] * (
+                                mmn.bk_cart[ib1, :, None] *
+                                mmn.bk_cart[ib2, None, :]))[None, None, :, :]
                     if phase is not None:
-                        CC_q_ik_ib *= phase[:, :, ib1_unique, ib2_unique]
+                        CC_q_ik_ib *= phase[:, :, ib1, ib2]
                     if sum_b:
                         CC_qb[ik] += CC_q_ik_ib
                     else:
-                        CC_qb[ik, :, :, ib1_unique, ib2_unique] = CC_q_ik_ib
+                        CC_qb[ik, :, :, ib1, ib2] = CC_q_ik_ib
         return CC_qb
 
     # --- C_a(q,b1,b2) matrix --- #
@@ -378,16 +376,15 @@ class CheckPoint:
         for ik in range(self.num_kpts):
             for ib in range(mmn.NNB):
                 iknb = mmn.neighbours[ik, ib]
-                ib_unique = mmn.ib_unique_map[ik, ib]
                 SHAW = self.wannier_gauge(shu.data[ik, ib], ik, iknb)
-                SHA_q_ik_ib = 1.j * SHAW[:, :, None, :] * mmn.wk[ik, ib] * mmn.bk_cart[ik, ib, None, None, :, None]
+                SHA_q_ik_ib = 1.j * SHAW[:, :, None, :] * mmn.wk[ib] * mmn.bk_cart[ib, None, None, :, None]
 
                 if phase is not None:
-                    SHA_q_ik_ib *= phase[:, :, ib_unique, None, None]
+                    SHA_q_ik_ib *= phase[:, :, ib, None, None]
                 if sum_b:
                     SHA_qb[ik] += SHA_q_ik_ib
                 else:
-                    SHA_qb[ik, :, :, ib_unique, :, :] = SHA_q_ik_ib
+                    SHA_qb[ik, :, :, ib] = SHA_q_ik_ib
 
         return SHA_qb
 
@@ -407,13 +404,12 @@ class CheckPoint:
             SHW = self.wannier_gauge(SH, ik, ik)
             for ib in range(mmn.NNB):
                 iknb = mmn.neighbours[ik, ib]
-                ib_unique = mmn.ib_unique_map[ik, ib]
                 SHM = np.tensordot(SH, mmn.data[ik, ib], axes=((1,), (0,))).swapaxes(-1, -2)
                 SHRW = self.wannier_gauge(SHM, ik, iknb)
                 if phase is not None:
-                    SHRW = SHRW * phase[:, :, ib_unique, None]
+                    SHRW = SHRW * phase[:, :, ib, None]
                 SHRW = SHRW - SHW
-                SHR_q[ik, :, :, :, :] += 1.j * SHRW[:, :, None] * mmn.wk[ik, ib] * mmn.bk_cart[ik, ib, None, None, :, None]
+                SHR_q[ik, :, :, :, :] += 1.j * SHRW[:, :, None] * mmn.wk[ib] * mmn.bk_cart[ib, None, None, :, None]
         return SHR_q
 
 

--- a/wannierberri/w90files/mmn.py
+++ b/wannierberri/w90files/mmn.py
@@ -115,7 +115,7 @@ class MMN(W90_file):
         return self.__class__(data=data)
 
     def set_bk(self, kpt_latt, mp_grid, recip_lattice, kmesh_tol=1e-7, bk_complete_tol=1e-5):
-        if all(hasattr(self, attr) for attr in ['bk_cart', 'wk', 'bk_latt_unique', 'bk_cart_unique', 'ib_unique_map']):
+        if all(hasattr(self, attr) for attr in ['bk_cart', 'wk', 'bk_latt', 'reorder_bk']):
             return
         else:
             # these are bk read from the mmn file
@@ -126,11 +126,11 @@ class MMN(W90_file):
                         for nbrs, G in zip(self.neighbours.T, self.G.transpose(1, 0, 2))
                     ]).transpose(1, 0, 2),
                 dtype=int)
-            # in the mmn file the bk are ordered in a different way for each k-point. 
+            # in the mmn file the bk are ordered in a different way for each k-point.
             # further we reorder them in the same way for all k-points
             # the order is also in the ascending order of the length of the vectors
             # vectors of same lengths are orderted in an arbitrary way, but consistently for all k-points
-            print ("bk_latt\n",bk_latt)
+            # print ("bk_latt\n",bk_latt)
             bk_latt_unique = np.array([b for b in set(tuple(bk) for bk in bk_latt.reshape(-1, 3))], dtype=int)
             assert len(bk_latt_unique) == self.NNB
             bk_cart_unique = bk_latt_unique.dot(recip_lattice / mp_grid[:, None])
@@ -139,8 +139,8 @@ class MMN(W90_file):
             bk_latt_unique = bk_latt_unique[srt]
             bk_cart_unique = bk_cart_unique[srt]
             bk_cart_unique_length = bk_cart_unique_length[srt]
-            brd = ( [0,] 
-                   + list(np.where(bk_cart_unique_length[1:] - bk_cart_unique_length[:-1] > kmesh_tol)[0] + 1) + 
+            brd = ([0,] +
+                   list(np.where(bk_cart_unique_length[1:] - bk_cart_unique_length[:-1] > kmesh_tol)[0] + 1) +
                    [self.NNB,])
             shell_mat = np.array([bk_cart_unique[b1:b2].T.dot(bk_cart_unique[b1:b2]) for b1, b2 in zip(brd, brd[1:])])
             shell_mat_line = shell_mat.reshape(-1, 9)
@@ -163,56 +163,26 @@ class MMN(W90_file):
             # k_cart = np.array([[bk_cart_dict[tuple(bkl)] for bkl in bklk] for bklk in bk_latt])
             self.wk = np.array([[weight_dict[tuple(bkl)] for bkl in bklk] for bklk in bk_latt])
 
-            self.reorder_bk = []
+            reorder_bk = []
             bk_latt_unique_tuples = [tuple(b) for b in bk_latt_unique]
             for ik in range(self.NK):
                 bk_latt_ik = [tuple(b) for b in bk_latt[ik]]
-                self.reorder_bk.append([bk_latt_ik.index(b) for b in bk_latt_unique_tuples])
-            self.reorder_bk = np.array(self.reorder_bk)
-            print ("bk_latt_unique\n",bk_latt_unique)
-            print ("self.reorder_bk\n",self.reorder_bk)
+                reorder_bk.append([bk_latt_ik.index(b) for b in bk_latt_unique_tuples])
+            self.reorder_bk = np.array(reorder_bk)
+            # print(f"reorder_bk set to = {self.reorder_bk}")
 
             for ik in range(self.NK):
-                self.data[ik] = self.data[ik,self.reorder_bk[ik]]
-                self.G[ik] = self.G[ik,self.reorder_bk[ik]]
-                self.neighbours[ik] = self.neighbours[ik,self.reorder_bk[ik]]
-                self.wk[ik] = self.wk[ik,self.reorder_bk[ik]]
-            
-            self.bk_cart = np.array([bk_cart_unique for _ in range(self.NK)])
+                self.data[ik] = self.data[ik, self.reorder_bk[ik]]
+                self.G[ik] = self.G[ik, self.reorder_bk[ik]]
+                self.neighbours[ik] = self.neighbours[ik, self.reorder_bk[ik]]
+
+            self.wk = self.wk[0, self.reorder_bk[0]]
+
+            # self.bk_cart = np.array([bk_cart_unique for _ in range(self.NK)])
             # so far we keep these long arrays bk_cart and wk_cart, although they contain copies of the same data
-            self.bk_latt_unique = bk_latt_unique
-            self.bk_cart_unique = bk_cart_unique
-            self.ib_unique_map = np.array([np.arange(self.NNB) for _ in range(self.NK)])
+            self.bk_latt = bk_latt_unique
+            self.bk_cart = bk_cart_unique
 
-            #############
-            ### Oscar ###
-            ###################################################################
-
-            # Wannier90 provides a list of nearest-neighbor vectors b for every
-            # q point. For Jae-Mo's finite-difference scheme it is convenient
-            # to evaluate the Fourier transform of the matrix elements in the
-            # original ab-initio mesh before performing the sum over
-            # nearest-neighbor vectors. This requires defining a mapping from
-            # any pair {q,b} to a unique list of b vectors that is independent
-            # of q.
-
-            bk_latt = np.rint((self.bk_cart @ np.linalg.inv(recip_lattice)) * mp_grid[None, None, :]).astype(int)
-            bk_latt_unique = np.unique(bk_latt.reshape(-1, 3), axis=0)
-            bk_cart_unique = (bk_latt_unique / mp_grid[None, :]) @ recip_lattice
-            assert bk_latt_unique.shape == (self.NNB, 3)
-
-            ib_unique_map = np.zeros((self.NK, self.NNB), dtype=int)
-            for ik in range(self.NK):
-                for ib in range(self.NNB):
-                    b_latt = np.rint((self.bk_cart[ik, ib, :] @ np.linalg.inv(recip_lattice)) * mp_grid).astype(int)
-                    ib_unique = [tuple(b) for b in bk_latt_unique].index(tuple(b_latt))
-                    assert np.allclose(bk_cart_unique[ib_unique, :], self.bk_cart[ik, ib, :])
-                    ib_unique_map[ik, ib] = ib_unique
-
-            self.bk_latt_unique = bk_latt_unique
-            self.bk_cart_unique = bk_cart_unique
-            self.ib_unique_map = ib_unique_map
-            ###################################################################
 
     def set_bk_chk(self, chk, **argv):
         self.set_bk(chk.kpt_latt, chk.mp_grid, chk.recip_lattice, **argv)

--- a/wannierberri/w90files/w90data.py
+++ b/wannierberri/w90files/w90data.py
@@ -182,10 +182,11 @@ class Wannier90data:
         if key in ["uhu", "uiu", "shu", "siu"]:
             kwargs["formatted"] = key in self.formatted_list
             kwargs["reorder_bk"] = self.mmn.reorder_bk
+            # print ("in kwargs_auto using reorder_bk",self.mmn.reorder_bk)
         if key not in ["chk", "win"]:
             kwargs["read_npz"] = self.read_npz
             kwargs["write_npz"] = key in self.write_npz_list
-        print(f"kwargs for {key} are {kwargs}")
+        # print(f"kwargs for {key} are {kwargs}")
         return kwargs
 
 
@@ -378,7 +379,6 @@ class Wannier90data:
                 new_files[file] = self.get_file(file).get_disentangled(v_left, v_right)
                 if file == 'mmn':
                     new_files[file].neighbours = self.mmn.neighbours
-                    new_files[file].ib_unique_map = self.mmn.ib_unique_map
                     new_files[file].G = self.mmn.G
         win = deepcopy(self.win)
         win.NB = self.chk.num_wann

--- a/wannierberri/w90files/w90data.py
+++ b/wannierberri/w90files/w90data.py
@@ -139,11 +139,11 @@ class Wannier90data:
             `~wannierberri.system.w90_files.MMN`, `~wannierberri.system.w90_files.EIG`, `~wannierberri.system.w90_files.AMN`, `~wannierberri.system.w90_files.UIU`, `~wannierberri.system.w90_files.UHU`, `~wannierberri.system.w90_files.SIU`, `~wannierberri.system.w90_files.SHU`, `~wannierberri.system.w90_files.SPN`
             for more details        
         """
-        kwargs_auto = self.auto_kwargs_files(key)
-        kwargs_auto.update(kwargs)
         if not overwrite and key in self._files:
             raise RuntimeError(f"file '{key}' was already set")
         if val is None:
+            kwargs_auto = self.auto_kwargs_files(key)
+            kwargs_auto.update(kwargs)
             val = self.__files_classes[key](self.seedname, **kwargs_auto)
         self.check_conform(key, val)
         self._files[key] = val
@@ -181,6 +181,7 @@ class Wannier90data:
         kwargs = {}
         if key in ["uhu", "uiu", "shu", "siu"]:
             kwargs["formatted"] = key in self.formatted_list
+            kwargs["reorder_bk"] = self.mmn.reorder_bk
         if key not in ["chk", "win"]:
             kwargs["read_npz"] = self.read_npz
             kwargs["write_npz"] = key in self.write_npz_list

--- a/wannierberri/w90files/w90file.py
+++ b/wannierberri/w90files/w90file.py
@@ -30,7 +30,8 @@ class W90_file(abc.ABC):
             self.data = data
             return
         f_npz = f"{seedname}.{ext}.npz"
-        print(f"calling w90 file with {seedname}, {ext}, tags={tags}, read_npz={read_npz}, write_npz={write_npz}, kwargs={kwargs}")
+        kwargs_str = "; ".join([f"{k}={v}" for k, v in kwargs.items() if k not in ["reorder_bk", ]])
+        print(f"calling w90 file with {seedname}, {ext}, tags={tags}, read_npz={read_npz}, write_npz={write_npz}, kwargs={kwargs_str}")
         if os.path.exists(f_npz) and read_npz:
             dic = np.load(f_npz)
             for k in tags:

--- a/wannierberri/w90files/xxu.py
+++ b/wannierberri/w90files/xxu.py
@@ -33,9 +33,10 @@ class UXU(W90_file):
             header = readstr(f_uXu_in)
             NB, NK, NNB = f_uXu_in.read_record('i4')
 
-        if reorder_bk.lower() == "do not reorder":
+        if isinstance(reorder_bk, str) and reorder_bk == "do not reorder":
+            print("!!not reordering!!")
             reorder_bk = np.array([np.arange(NNB)] * NK)
-        
+
         assert reorder_bk.shape == (NK, NNB), f"reorder_bk.shape = {reorder_bk.shape} != ({NK}, {NNB}) = (NK, NNB)"
 
         print(f"reading {seedname}.{suffix} : <{header}>")
@@ -51,7 +52,7 @@ class UXU(W90_file):
                     for ib1 in range(NNB):
                         tmp = f_uXu_in.read_record('f8').reshape((2, NB, NB), order='F').transpose(2, 1, 0)
                         self.data[ik, ib1, ib2] = tmp[:, :, 0] + 1j * tmp[:, :, 1]
-                self.data[ik] = self.data[ik, reorder_bk[ik], :][ :, reorder_bk[ik]]
+                self.data[ik] = self.data[ik, reorder_bk[ik], :][:, reorder_bk[ik]]
         print(f"----------\n {suffix} OK  \n---------\n")
         f_uXu_in.close()
 
@@ -125,7 +126,8 @@ class SXU(W90_file):
             header = readstr(f_sXu_in)
             NB, NK, NNB = f_sXu_in.read_record('i4')
 
-        if reorder_bk.lower() == "do not reorder":
+        if isinstance(reorder_bk, str) and reorder_bk == "do not reorder":
+            print("!!not reordering!!")
             reorder_bk = np.array([np.arange(NNB)] * NK)
 
         assert reorder_bk.shape == (NK, NNB), f"reorder_bk.shape = {reorder_bk.shape} != ({NK}, {NNB}) = (NK, NNB)"

--- a/wannierberri/w90files/xxu.py
+++ b/wannierberri/w90files/xxu.py
@@ -33,6 +33,9 @@ class UXU(W90_file):
             header = readstr(f_uXu_in)
             NB, NK, NNB = f_uXu_in.read_record('i4')
 
+        if reorder_bk.lower() == "do not reorder":
+            reorder_bk = np.array([np.arange(NNB)] * NK)
+        
         assert reorder_bk.shape == (NK, NNB), f"reorder_bk.shape = {reorder_bk.shape} != ({NK}, {NNB}) = (NK, NNB)"
 
         print(f"reading {seedname}.{suffix} : <{header}>")
@@ -121,6 +124,9 @@ class SXU(W90_file):
             f_sXu_in = FortranFileR(seedname + "." + suffix)
             header = readstr(f_sXu_in)
             NB, NK, NNB = f_sXu_in.read_record('i4')
+
+        if reorder_bk.lower() == "do not reorder":
+            reorder_bk = np.array([np.arange(NNB)] * NK)
 
         assert reorder_bk.shape == (NK, NNB), f"reorder_bk.shape = {reorder_bk.shape} != ({NK}, {NNB}) = (NK, NNB)"
         print(f"reading {seedname}.{suffix} : <{header}>")


### PR DESCRIPTION
Now during the read of  mmn file, the bk vectors (pointing to nearest neighbors in k-grid) are ordered consistently for all k-points.
This order is also ascending in the lengths of b-vectors (when they differ, within the group of b-vectors of same length they are ordered arbitrary, but consistently for all k-points)
During the read of uHu uIu, sHu, sIu files the ordering is done accordingly

Now bk_cart and bk_latt have dimensions (NNB, 3)  , and weights are NNB - same for all k-points

Thus,  no need for bk)cart_unique, bk_latt_unique

Accordingly, the code for finite-difference is simplified.