### PR TITLE
Fix bugs in SAWF

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ extras_require = {
                 # https://developers.google.com/protocol-buffers/docs/news/2022-05-06#python-updates
     "fftw"     : ['pyFFTW>=0.12.0'],
     "plot"     : ['matplotlib'],
-    "symmetry" : [ 'sympy', 'spglib>=2', 'irrep>=2.2', 'spgrep'],
+    "symmetry" : [ 'sympy', 'spglib>=2', 'irrep>=2.3.3', 'spgrep'],
     "phonons"  : [ 'untangle' ],
                 }
 

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ setuptools.setup(
      description="Constructuion of Wannier functions and Wannier interpolation",
      long_description=long_description,
      long_description_content_type="text/markdown",
-     python_requires='>=3.10',
+     python_requires='>=3.11',
      install_requires=[
                         'numpy>=2.0', 
                         'scipy>=1.13',

--- a/tests/test_aux.py
+++ b/tests/test_aux.py
@@ -3,7 +3,7 @@
 import numpy as np
 from pytest import approx
 from wannierberri.formula.covariant import _spin_velocity_einsum_opt
-from wannierberri.utility import cached_einsum, vectorize
+from wannierberri.utility import cached_einsum, vectorize, arr_to_string
 
 
 def test_spin_velocity_einsum_opt():
@@ -44,3 +44,10 @@ def test_vectorized_matrix_prod():
         for a, b, c in zip(A, B, C):
             c1 = np.dot(a, b)
             assert c == approx(c1)
+
+
+def test_arr_to_string():
+    a = np.array([[1.123456789, 2.123456789], [3.123456789, 4.123456789]])
+    s = arr_to_string(a, fmt="{:8.4f}")
+    expected = "  1.1235  2.1235\n  3.1235  4.1235"
+    assert s == expected, f"Got: \n{s}, expected: \n{expected}"

--- a/tests/test_projections.py
+++ b/tests/test_projections.py
@@ -315,6 +315,11 @@ def test_create_amn_diamond_s_bond():
     print("eig.shape = ", w90data.eig.data[0].shape)
     w90data.set_file("amn", amn)
     w90data.set_symmetrizer(symmetrizer=symmetrizer)
+    err_mmn = symmetrizer.check_mmn(w90data.get_file("mmn"), ignore_upper_bands=2)
+    assert err_mmn < 1e-6, f"mmn is not symmetric, error={err_mmn}"
+    err_amn = symmetrizer.check_amn(amn, ignore_upper_bands=2)
+    assert err_amn < 1e-6, f"amn is not symmetric, error={err_amn}"
+
     # Now wannierise the system
     w90data.wannierise(
         froz_min=-8,
@@ -343,7 +348,7 @@ def test_create_amn_diamond_p_bond():
 
     bandstructure = irrep.bandstructure.BandStructure(prefix=data_dir + "/di", Ecut=100,
                                                       code="espresso",
-                                                    include_TR=False,
+                                                    include_TR=True,
                                                       )
     lattice = bandstructure.lattice
     positions = np.array([[1, 1, 1], [-1, -1, -1]])
@@ -351,7 +356,10 @@ def test_create_amn_diamond_p_bond():
     print("zaxis = ", zaxis)
 
 
-    projection = Projection(position_num=[0, 0, 0], orbital='pz', zaxis=zaxis, spacegroup=bandstructure.spacegroup, rotate_basis=True)
+    # projection = Projection(position_num=[0, 0, 0], orbital='pz', zaxis=zaxis, spacegroup=bandstructure.spacegroup, rotate_basis=True)
+    projection = Projection(position_num=[[0, 0, 0], [0, 0, 1 / 2], [0, 1 / 2, 0], [1 / 2, 0, 0]], orbital='pz', zaxis=zaxis, spacegroup=bandstructure.spacegroup, rotate_basis=True)
+
+    
     print("positions_cart = ", projection.positions @ lattice)
 
     amn = amn_from_bandstructure(bandstructure=bandstructure, projections=ProjectionsSet([projection]),
@@ -359,6 +367,14 @@ def test_create_amn_diamond_p_bond():
     symmetrizer = SAWF().from_irrep(bandstructure)
     symmetrizer.set_D_wann_from_projections([projection])
 
+    lattice = symmetrizer.spacegroup.lattice
+    print (f"lattice = \n {lattice}")
+    print (f"positions_atoms_cart \n{ np.array([[1, 1, 1], [-1, -1, -1]])/8 @ lattice }")
+    print (f"positions_cart = \n {projection.positions @ lattice}")
+    print (f"basis_list = \n{projection.basis_list}")
+    print (f"rot_orb = \n {symmetrizer.rot_orb_list}")
+    # exit()
+    
     tmp_dir = os.path.join(OUTPUT_DIR, "diamond+create_amn")
 
     # Check if the directory exists
@@ -382,40 +398,44 @@ def test_create_amn_diamond_p_bond():
         seedname=os.path.join(tmp_dir, prefix),
         readfiles=["mmn", "eig", "win", "unk"])
     w90data.set_file("amn", amn)
+    err_mmn = symmetrizer.check_mmn(w90data.get_file("mmn"), ignore_upper_bands=2)
+    assert err_mmn < 1e-6, f"mmn is not symmetric, error={err_mmn}"
+    err_amn = symmetrizer.check_amn(amn, ignore_upper_bands=2)
+    assert err_amn < 1e-6, f"amn is not symmetric, error={err_amn}"
+
+    
     w90data.set_symmetrizer(symmetrizer=symmetrizer)
     amn_symm_prec = symmetrizer.check_amn(amn, ignore_upper_bands=2)
-    w90data.select_bands(win_min=20, win_max=100)
+    w90data.select_bands(win_min=20, win_max=1000)
     print(f"amn is symmetric with accuracy {amn_symm_prec}")
     # Now wannierise the system
     w90data.wannierise(
         froz_min=22,
-        froz_max=35,
-        num_iter=20,
+        froz_max=30,
+        num_iter=100,
         conv_tol=1e-10,
-        mix_ratio_z=0.8,
+        mix_ratio_z=1,
         mix_ratio_u=1,
         print_progress_every=1,
         sitesym=True,
-        localise=True
+        # localise=True
     )
     w90data.plotWF()
 
     wannier_centers = w90data.chk.wannier_centers_cart
     print("wannierr_centers = ", wannier_centers)
-    # assert wannier_centers == approx(0.806995*np.array([[0, 0, 0], [-1,1,0], [0,1,1], [-1,0,1]]), abs=1e-6)
+    assert wannier_centers == approx(0.806995*np.array([[0, 0, 0], [-1,1,0], [0,1,1], [-1,0,1]]), abs=1e-6)
     wannier_spreads = w90data.chk.wannier_spreads
+    V = np.array([w90data.chk.v_matrix[k] for k in range(w90data.chk.NK)])
+    print (f"shape of V matrix {V.shape}")
+    err_chk = symmetrizer.check_amn( V, verbose=True, ignore_upper_bands=None)
+    print (f"max error in chk : {err_chk}")
     print("wannier_spreads = ", wannier_spreads)
     # assert wannier_spreads == approx(.398647548, abs=1e-5)
 
-    a = -wannier_centers[1, 0]
-
-    wannier_centers_ab = np.array([[0, 0, 0], [-1, 0, 1], [-1, 1, 0], [0, 1, 1]]) * a
-    assert wannier_centers == approx(wannier_centers_ab, abs=1e-6)
     assert wannier_spreads == approx(wannier_spreads.mean(), abs=1e-6)
 
-    expected_spread = 1.4
-    expected_a = -lattice[0, 0] / 2
-    assert a == approx(expected_a, abs=1e-6)
+    expected_spread = 0.732778118
     assert wannier_spreads == approx(expected_spread, abs=0.5)
 
 
@@ -424,7 +444,7 @@ def test_create_amn_diamond_sp3():
 
     bandstructure = irrep.bandstructure.BandStructure(prefix=data_dir + "/di", Ecut=100,
                                                       code="espresso",
-                                                    include_TR=False,
+                                                    include_TR=True,
                                                       )
     lattice = bandstructure.lattice
     positions = np.array([[1, 1, 1], [-1, -1, -1]]) / 8
@@ -432,6 +452,9 @@ def test_create_amn_diamond_sp3():
                             spacegroup=bandstructure.spacegroup, rotate_basis=True)
     projections = ProjectionsSet([projection_sp3])
     print(f"lattice = {lattice}")
+    pos_atoms_cart = positions @ lattice
+    print("positions_cart = ", projection_sp3.positions @ lattice)
+
     amn = amn_from_bandstructure(bandstructure=bandstructure, projections=projections,
                            normalize=True, return_object=True)
     symmetrizer = SAWF().from_irrep(bandstructure)
@@ -461,8 +484,8 @@ def test_create_amn_diamond_sp3():
     print(f"amn is symmetric with accuracy {amn_symm_prec}")
     # Now wannierise the system
     w90data.wannierise(
-        # froz_min=-20,
-        # froz_max=35,
+        froz_min=-20,
+        froz_max=35,
         num_iter=20,
         conv_tol=1e-10,
         mix_ratio_z=1,
@@ -479,28 +502,33 @@ def test_create_amn_diamond_sp3():
     wannier_spreads = w90data.chk.wannier_spreads
     print("wannier_spreads = ", wannier_spreads)
 
-    a = -wannier_centers[0, 0]
-    b = wannier_centers[0, 1]
-    wannier_centers_ab = np.array([[-a, b, b],
-                                   [-a, a, a],
-                                   [-b, b, a],
-                                   [-b, a, b],
-                                   [a, -a, -a],
-                                   [b, -a, -b],
-                                   [a, -b, -b],
-                                   [b, -b, -a]])
-    assert wannier_centers == approx(wannier_centers_ab, abs=1e-6)
+    shifts1 = wannier_centers[:4, :] - pos_atoms_cart[0, None, :]
+    shifts2 = wannier_centers[4:, :] - pos_atoms_cart[1, None, :]
+
+    print("shifts1 = \n", shifts1)
+    print("shifts2 = \n", shifts2)
+
+    shift_abs = np.mean(np.abs(np.concatenate([shifts1, shifts2], axis=0)))
+
+    print("shift_abs = ", shift_abs)
+
+    assert shift_abs == approx(0.13779566, abs=1e-3)
+
+    assert shifts1 == approx(shift_abs*np.array([[+1, +1,+1],
+                                                 [+1, -1,-1],
+                                                 [-1, +1,-1],
+                                                 [-1, -1,+1]]), abs=1e-5)
+    assert shifts2 == approx(shift_abs*np.array([[-1, +1,+1],
+                                                 [+1, +1,-1],
+                                                 [-1,-1,-1],
+                                                 [+1, -1,+1]]), abs=1e-5)
+
     assert wannier_spreads == approx(wannier_spreads.mean(), abs=1e-6)
 
 
-    expected_spread = 0.432977363501
-    expected_a = 0.2504700607869765
-    expected_b = 0.55652500
-    assert a == approx(expected_a, abs=1e-2)
-    assert b == approx(expected_b, abs=1e-2)
-    assert wannier_spreads == approx(expected_spread, abs=1e-2)
+    expected_spread = 0.5
+    assert wannier_spreads == approx(expected_spread, abs=0.1)
 
-    # assert wannier_spreads == approx(.398647548, abs=1e-5)
 
 
 def test_create_eig_diamond():

--- a/tests/test_projections.py
+++ b/tests/test_projections.py
@@ -359,7 +359,7 @@ def test_create_amn_diamond_p_bond():
     # projection = Projection(position_num=[0, 0, 0], orbital='pz', zaxis=zaxis, spacegroup=bandstructure.spacegroup, rotate_basis=True)
     projection = Projection(position_num=[[0, 0, 0], [0, 0, 1 / 2], [0, 1 / 2, 0], [1 / 2, 0, 0]], orbital='pz', zaxis=zaxis, spacegroup=bandstructure.spacegroup, rotate_basis=True)
 
-    
+
     print("positions_cart = ", projection.positions @ lattice)
 
     amn = amn_from_bandstructure(bandstructure=bandstructure, projections=ProjectionsSet([projection]),
@@ -368,13 +368,13 @@ def test_create_amn_diamond_p_bond():
     symmetrizer.set_D_wann_from_projections([projection])
 
     lattice = symmetrizer.spacegroup.lattice
-    print (f"lattice = \n {lattice}")
-    print (f"positions_atoms_cart \n{ np.array([[1, 1, 1], [-1, -1, -1]])/8 @ lattice }")
-    print (f"positions_cart = \n {projection.positions @ lattice}")
-    print (f"basis_list = \n{projection.basis_list}")
-    print (f"rot_orb = \n {symmetrizer.rot_orb_list}")
+    print(f"lattice = \n {lattice}")
+    print(f"positions_atoms_cart \n{np.array([[1, 1, 1], [-1, -1, -1]]) / 8 @ lattice}")
+    print(f"positions_cart = \n {projection.positions @ lattice}")
+    print(f"basis_list = \n{projection.basis_list}")
+    print(f"rot_orb = \n {symmetrizer.rot_orb_list}")
     # exit()
-    
+
     tmp_dir = os.path.join(OUTPUT_DIR, "diamond+create_amn")
 
     # Check if the directory exists
@@ -403,7 +403,7 @@ def test_create_amn_diamond_p_bond():
     err_amn = symmetrizer.check_amn(amn, ignore_upper_bands=2)
     assert err_amn < 1e-6, f"amn is not symmetric, error={err_amn}"
 
-    
+
     w90data.set_symmetrizer(symmetrizer=symmetrizer)
     amn_symm_prec = symmetrizer.check_amn(amn, ignore_upper_bands=2)
     w90data.select_bands(win_min=20, win_max=1000)
@@ -424,12 +424,12 @@ def test_create_amn_diamond_p_bond():
 
     wannier_centers = w90data.chk.wannier_centers_cart
     print("wannierr_centers = ", wannier_centers)
-    assert wannier_centers == approx(0.806995*np.array([[0, 0, 0], [-1,1,0], [0,1,1], [-1,0,1]]), abs=1e-6)
+    assert wannier_centers == approx(0.806995 * np.array([[0, 0, 0], [-1, 1, 0], [0, 1, 1], [-1, 0, 1]]), abs=1e-6)
     wannier_spreads = w90data.chk.wannier_spreads
     V = np.array([w90data.chk.v_matrix[k] for k in range(w90data.chk.NK)])
-    print (f"shape of V matrix {V.shape}")
-    err_chk = symmetrizer.check_amn( V, verbose=True, ignore_upper_bands=None)
-    print (f"max error in chk : {err_chk}")
+    print(f"shape of V matrix {V.shape}")
+    err_chk = symmetrizer.check_amn(V, verbose=True, ignore_upper_bands=None)
+    print(f"max error in chk : {err_chk}")
     print("wannier_spreads = ", wannier_spreads)
     # assert wannier_spreads == approx(.398647548, abs=1e-5)
 
@@ -514,14 +514,14 @@ def test_create_amn_diamond_sp3():
 
     assert shift_abs == approx(0.13779566, abs=1e-3)
 
-    assert shifts1 == approx(shift_abs*np.array([[+1, +1,+1],
-                                                 [+1, -1,-1],
-                                                 [-1, +1,-1],
-                                                 [-1, -1,+1]]), abs=1e-5)
-    assert shifts2 == approx(shift_abs*np.array([[-1, +1,+1],
-                                                 [+1, +1,-1],
-                                                 [-1,-1,-1],
-                                                 [+1, -1,+1]]), abs=1e-5)
+    assert shifts1 == approx(shift_abs * np.array([[+1, +1, +1],
+                                                 [+1, -1, -1],
+        [-1, +1, -1],
+        [-1, -1, +1]]), abs=1e-5)
+    assert shifts2 == approx(shift_abs * np.array([[-1, +1, +1],
+                                                 [+1, +1, -1],
+        [-1, -1, -1],
+        [+1, -1, +1]]), abs=1e-5)
 
     assert wannier_spreads == approx(wannier_spreads.mean(), abs=1e-6)
 

--- a/tests/test_wannierise.py
+++ b/tests/test_wannierise.py
@@ -12,9 +12,8 @@ from .common import OUTPUT_DIR, ROOT_DIR, REF_DIR
 from wannierberri.symmetry.sawf import SymmetrizerSAWF
 
 
-@pytest.mark.parametrize("outer_window", [None, (-100, 100), (-10, 40), (-10, 22), (10, 40)])
+@pytest.mark.parametrize("outer_window", [None, (-100, 100), (-10, 40), (-10, 22),])
 def test_wannierise(outer_window):
-    check_results = (outer_window is None or outer_window[0] < -9)
     systems = {}
 
     cwd = os.getcwd()
@@ -56,28 +55,26 @@ def test_wannierise(outer_window):
         mix_ratio_u=1,
         print_progress_every=20,
         sitesym=True,
-        localise=True
+        localise=True,
     )
     wannier_centers = w90data.chk.wannier_centers_cart
     wannier_spreads = w90data.chk.wannier_spreads
     wannier_spreads_mean = np.mean(wannier_spreads)
-    if check_results:
-        assert wannier_spreads == approx(wannier_spreads_mean, abs=1e-9)
-        assert wannier_spreads == approx(0.39864755, abs=1e-5)
-        assert wannier_centers == approx(np.array([[0, 0, 0],
-                                                [0, 0, 1],
-            [0, 1, 0],
-            [1, 0, 0]
-        ]).dot(w90data.chk.real_lattice) / 2,
-            abs=1e-6)
+    assert wannier_spreads == approx(wannier_spreads_mean, abs=1e-9)
+    assert wannier_spreads == approx(0.39864755, abs=1e-5)
+    assert wannier_centers == approx(np.array([[0, 0, 0],
+                                            [0, 0, 1],
+        [0, 1, 0],
+        [1, 0, 0]
+    ]).dot(w90data.chk.real_lattice) / 2,
+        abs=1e-6)
     sc_origin, sc_basis, WF, rho = w90data.plotWF(select_WF=[1, 2], reduce_r_points=[3, 9, 1])
     assert WF.shape == (2, 6, 2, 18)
     assert rho.shape == (2, 6, 2, 18)
-    if check_results:
-        wf_file_name = "WF_12_red.npy"
-        np.save(wf_file_name, WF)
-        ref = np.load(os.path.join(REF_DIR, wf_file_name))
-        assert WF == approx(ref)
+    wf_file_name = "WF_12_red.npy"
+    np.save(wf_file_name, WF)
+    ref = np.load(os.path.join(REF_DIR, wf_file_name))
+    assert WF == approx(ref)
 
     sc_origin, sc_basis, WF, rho = w90data.plotWF(select_WF=[1, 2], reduce_r_points=[1, 1, 1])
     lattice = w90data.chk.real_lattice
@@ -85,8 +82,7 @@ def test_wannierise(outer_window):
     assert sc_basis == approx(2 * lattice)
     assert WF.shape == (2, 18, 18, 18)
     assert rho.shape == (2, 18, 18, 18)
-    if check_results:
-        assert rho.sum(axis=(1, 2, 3)) == approx(1)
+    assert rho.sum(axis=(1, 2, 3)) == approx(1)
 
     systems["wberri"] = wberri.system.System_w90(w90data=w90data)
 
@@ -120,8 +116,7 @@ def test_wannierise(outer_window):
         diff = abs(energies[k1] - energies_ref)
         # the precidsion is not very high here, although the two codes are assumed to do the same. Not sure why..
         d, acc = np.max(diff), 0.0005
-        if check_results:
-            assert d < acc, f"the interpolated bands {k1}  differ from reference by max {d}>{acc}"
+        assert d < acc, f"the interpolated bands {k1}  differ from reference by max {d}>{acc}"
     # One can see that results do not differ much. Also, the maximal localization does not have much effect.
     os.chdir(cwd)
 

--- a/wannierberri/symmetry/Dwann.py
+++ b/wannierberri/symmetry/Dwann.py
@@ -43,6 +43,10 @@ class Dwann:
         Number of symmetry operations in the spacegroup.
     atommap : np.ndarray(shape=(num_points, nsym), dtype=int)
         A matrix that maps the orbit points to each other by the symmetry operations of the spacegroup.
+        atommap[ip, isym] = ip2 means that the symmetry operation isym transforms the point ip to the point ip2.
+    T : np.ndarray(shape=(num_points, nsym, 3), dtype=int)
+        A matrix that contains the translation needed to bring the transformed point back to the home unit cell.
+        T[ip, isym] = ip - Symop( ip)
 
     Notes
     -----
@@ -82,7 +86,6 @@ class Dwann:
         self.num_orbitals = self.num_orbitals_scal * self.nspinor
 
         self.atommap = -np.ones((self.num_points, self.nsym), dtype=int)
-        self.rot_basis = np.zeros((self.num_points, self.nsym, 3, 3), dtype=float)
         self.T = np.zeros((self.num_points, self.nsym, 3), dtype=float)
 
         self.rot_orb = [[np.eye(self.num_orbitals_scal) for _ in range(self.nsym)] for _ in range(self.num_points)]

--- a/wannierberri/symmetry/orbitals.py
+++ b/wannierberri/symmetry/orbitals.py
@@ -409,7 +409,7 @@ class SphericalHarmonics:
         else:
             ibasis = len(self.calcualted_basices)
             self.calcualted_basices.append(basis)
-            print(f"new basis for spherical harmonics, \n {basis}\n total {len(self.calcualted_basices)} bases")
+            # print(f"new basis for spherical harmonics, \n {basis}\n total {len(self.calcualted_basices)} bases")
         if (orbital, ibasis) not in self.harmonics:
             self.harmonics[(orbital, ibasis)] = self._harmonics(orbital, basis)
         return self.harmonics[(orbital, ibasis)]
@@ -432,10 +432,10 @@ class SphericalHarmonics:
                 assert orbital in shell_list, f"orbital {orbital} not in shell {shell}"
                 shell_pos = shell_list.index(orbital)
                 # print(f"basis = \n{basis}")
-                matrix = self.orbitalrotator(shell, rot_cart=basis)  
+                matrix = self.orbitalrotator(shell, rot_cart=basis)
                 # print(f"matrix = \n{matrix}")
                 vector = matrix[shell_pos, :]
-                print(f" orbital {orbital} basis = \n{basis}\n,   vector = {vector}, shell_list = {shell_list}")
+                # print(f" orbital {orbital} basis = \n{basis}\n,   vector = {vector}, shell_list = {shell_list}")
                 return sum(self(o, basis=None) * k for k, o in zip(vector, shell_list))
             else:
                 match orbital:

--- a/wannierberri/symmetry/orbitals.py
+++ b/wannierberri/symmetry/orbitals.py
@@ -231,7 +231,7 @@ def get_orbitals():
 class OrbitalRotator:
     """
     a class to get the rotation matrix of orbitals under a given rotation
-    
+
 
     returns matrix Rij, where i is the index of the original orbital , and j is the index of the rotated orbital
 

--- a/wannierberri/symmetry/orbitals.py
+++ b/wannierberri/symmetry/orbitals.py
@@ -22,6 +22,7 @@ orbitals_sets_dic = {
     'f': ['fz3', 'fxz2', 'fyz2', 'fzx2-zy2', 'fxyz', 'fx3-3xy2', 'f3yx2-y3'],
     'sp': ['sp-1', 'sp-2'],
     'p2': ['pz', 'py'],
+    'pxy': ['px', 'py'],
     'sp2': ['sp2-1', 'sp2-2', 'sp2-3'],
     'pz': ['pz'],
     'sp3': ['sp3-1', 'sp3-2', 'sp3-3', 'sp3-4'],
@@ -32,7 +33,7 @@ orbitals_sets_dic = {
 }
 
 basis_shells_list = ['s', 'p', 'd', 'f']
-hybrid_shells_list = ['sp', 'p2', 'sp2', 'pz', 'sp3', 'sp3d2', 't2g', 'eg']
+hybrid_shells_list = ['sp', 'p2', 'sp2', 'pz', 'sp3', 'sp3d2', 't2g', 'eg', 'pxy']
 
 basis_orbital_list = [k for o in basis_shells_list for k in orbitals_sets_dic[o]]
 
@@ -158,7 +159,21 @@ class Orbitals:
 
 
     def rot_orb_basis(self, orb_symbol, rot_glb):
-        ''' Get rotation matrix of orbitals in each orbital quantum number '''
+        """Get rotation matrix of orbitals in each orbital quantum number
+        orb_symbol : str
+            one of 's', 'p', 'd', 'f'
+        rot_glb : 3x3 array
+            rotation matrix in cartesian coordinates
+        Returns
+        -------
+        orb_rot_mat : array
+            rotation matrix of shape (num_orbitals, num_orbitals)
+            where num_orbitals = 1, 3, 5, 7 for 's', 'p', 'd', 'f' respectively
+        Notes
+        -----
+        The rotation matrix A is defined as
+        phi_j(R^-1 r) = phi_i(r) A_ij where phi_i is the original orbital, phi'_i is the rotated orbital
+        """
         orb_dim = num_orbitals(orb_symbol)
         orb_rot_mat = np.zeros((orb_dim, orb_dim), dtype=float)
         xp, yp, zp = np.dot(np.linalg.inv(rot_glb), self.xyz)
@@ -214,6 +229,14 @@ def get_orbitals():
 
 
 class OrbitalRotator:
+    """
+    a class to get the rotation matrix of orbitals under a given rotation
+    
+
+    returns matrix Rij, where i is the index of the original orbital , and j is the index of the rotated orbital
+
+    phi'_j = phi_i R_ij
+    """
 
     def __init__(self):
         self.calcualted_matrices = UniqueList(tolerance=1e-4)
@@ -221,16 +244,18 @@ class OrbitalRotator:
         self.results_dict = {}
 
     def __call__(self, orb_symbol, rot_cart=None, irot=None, basis1=None, basis2=None):
+        # return self.orbitals.rot_orb(orb_symbol=orb_symbol, rot_glb=basis1.T @ rot_cart @ basis2)
+
         assert (basis1 is None) == (basis2 is None), "basis1 and basis2 should be both provided or both None"
         assert (irot is None) != (rot_cart is None), f"either irot or rot_cart should be provided, not both, got irot={irot}, rot_cart={rot_cart}"
         if irot is None:
             if basis1 is not None:
-                rot_cart = basis2 @ rot_cart @ basis1.T
+                rot_cart = basis1.T @ rot_cart @ basis2
             irot = self.calcualted_matrices.index_or_None(rot_cart)
             if irot is None:
                 irot = len(self.calcualted_matrices)
                 self.calcualted_matrices.append(rot_cart)
-        if rot_cart is None:
+        elif rot_cart is None:
             rot_cart = self.calcualted_matrices[irot]
         if (irot, orb_symbol) not in self.results_dict:
             orb_symbol = orb_symbol.strip()

--- a/wannierberri/symmetry/orbitals.py
+++ b/wannierberri/symmetry/orbitals.py
@@ -250,7 +250,8 @@ class OrbitalRotator:
         assert (irot is None) != (rot_cart is None), f"either irot or rot_cart should be provided, not both, got irot={irot}, rot_cart={rot_cart}"
         if irot is None:
             if basis1 is not None:
-                rot_cart = basis1.T @ rot_cart @ basis2
+                # rot_cart = basis1.T @ rot_cart @ basis2
+                rot_cart = basis2 @ rot_cart @ basis1.T
             irot = self.calcualted_matrices.index_or_None(rot_cart)
             if irot is None:
                 irot = len(self.calcualted_matrices)
@@ -408,6 +409,7 @@ class SphericalHarmonics:
         else:
             ibasis = len(self.calcualted_basices)
             self.calcualted_basices.append(basis)
+            print(f"new basis for spherical harmonics, \n {basis}\n total {len(self.calcualted_basices)} bases")
         if (orbital, ibasis) not in self.harmonics:
             self.harmonics[(orbital, ibasis)] = self._harmonics(orbital, basis)
         return self.harmonics[(orbital, ibasis)]
@@ -420,7 +422,7 @@ class SphericalHarmonics:
         from numpy import pi
         if orbital not in basis_orbital_list:
             assert orbital in hybrids_coef, f"orbital {orbital} not in basis_orbital_list or hybrids_coef"
-            return sum(self(orb) * coef for orb, coef in hybrids_coef[orbital].items())
+            return sum(self(orb, basis) * coef for orb, coef in hybrids_coef[orbital].items())
         else:
             if not np.allclose(basis, np.eye(3), atol=1e-4):
                 # print(f"evaluating orbital {orbital} in basis \n{basis}")
@@ -430,10 +432,10 @@ class SphericalHarmonics:
                 assert orbital in shell_list, f"orbital {orbital} not in shell {shell}"
                 shell_pos = shell_list.index(orbital)
                 # print(f"basis = \n{basis}")
-                matrix = self.orbitalrotator(shell, basis)
+                matrix = self.orbitalrotator(shell, rot_cart=basis)  
                 # print(f"matrix = \n{matrix}")
                 vector = matrix[shell_pos, :]
-                # print(f" orbital {orbital} basis = \n{basis}\n,   vector = {vector}, shell_list = {shell_list}")
+                print(f" orbital {orbital} basis = \n{basis}\n,   vector = {vector}, shell_list = {shell_list}")
                 return sum(self(o, basis=None) * k for k, o in zip(vector, shell_list))
             else:
                 match orbital:

--- a/wannierberri/symmetry/point_symmetry.py
+++ b/wannierberri/symmetry/point_symmetry.py
@@ -316,7 +316,7 @@ class PointGroup():
 
     def as_dict(self):
         nsym = len(self.symmetries)
-        ret = dict(real_lattice=self.recip_lattice,
+        ret = dict(real_lattice=self.real_lattice,
                    nsym=nsym)
         for i, s in enumerate(self.symmetries):
             for k, v in s.as_dict().items():

--- a/wannierberri/symmetry/point_symmetry.py
+++ b/wannierberri/symmetry/point_symmetry.py
@@ -263,10 +263,12 @@ class PointGroup():
     """
 
     def __init__(self, generator_list=[], recip_lattice=None, real_lattice=None, dictionary=None,
-                 spacegroup=None):
+                 spacegroup=None, use_symmetries_index=None):
         if spacegroup is not None:
             point_symmetries = []
-            for symop in spacegroup.symmetries:
+            for isym, symop in enumerate(spacegroup.symmetries):
+                if (use_symmetries_index is not None) and (isym not in use_symmetries_index):
+                    continue
                 R = symop.rotation_cart
                 TR = symop.time_reversal
                 point_symmetries.append(PointSymmetry(R, TR))

--- a/wannierberri/symmetry/projections.py
+++ b/wannierberri/symmetry/projections.py
@@ -100,6 +100,7 @@ class Projection:
                  rotate_basis=False,
                  zaxis=None,
                  xaxis=None,
+                 basis_list=None,
                  do_not_split_projections=False):
         if void:
             return
@@ -133,9 +134,11 @@ class Projection:
                 spinor = False
         self.spinor = spinor
 
-        if rotate_basis:
+        if basis_list is not None:
+            self.basis_list = np.array(basis_list)
+        elif rotate_basis:
             basis0 = read_xzaxis(xaxis, zaxis)
-            self.basis_list = [np.dot(basis0, rot.T) for rot in self.wyckoff_position.rotations_cart]
+            self.basis_list = [ basis0 @ rot.T for rot in self.wyckoff_position.rotations_cart]
         else:
             self.basis_list = [np.eye(3, dtype=float)] * self.num_points
 

--- a/wannierberri/symmetry/projections.py
+++ b/wannierberri/symmetry/projections.py
@@ -138,7 +138,7 @@ class Projection:
             self.basis_list = np.array(basis_list)
         elif rotate_basis:
             basis0 = read_xzaxis(xaxis, zaxis)
-            self.basis_list = [ basis0 @ rot.T for rot in self.wyckoff_position.rotations_cart]
+            self.basis_list = [basis0 @ rot.T for rot in self.wyckoff_position.rotations_cart]
         else:
             self.basis_list = [np.eye(3, dtype=float)] * self.num_points
 

--- a/wannierberri/symmetry/sawf.py
+++ b/wannierberri/symmetry/sawf.py
@@ -318,7 +318,7 @@ class SymmetrizerSAWF:
                     XX_L = wcc_red_in[start_a:start_a + norb]
                     if ncart > 0:
                         XX_L = symop.transform_r(XX_L) + T[atom_a]
-                    transformed = cached_einsum("ij,j...,ji->i...", self.rot_orb_dagger_list[block][atom_a, isym].T, XX_L, self.rot_orb_list[block][atom_a, isym].T).real
+                    transformed = cached_einsum("ij,j...,ji->i...", self.rot_orb_dagger_list[block][atom_a, isym], XX_L, self.rot_orb_list[block][atom_a, isym]).real
                     WCC_red_out[start_b:start_b + norb] += transformed
         if ncart > 0:
             WCC_red_out = WCC_red_out @ self.spacegroup.lattice

--- a/wannierberri/symmetry/sawf.py
+++ b/wannierberri/symmetry/sawf.py
@@ -1,4 +1,3 @@
-import copy
 from functools import cached_property, lru_cache
 import warnings
 from irrep.bandstructure import BandStructure
@@ -560,12 +559,12 @@ class SymmetrizerSAWF:
             when the error is larger than this value, a warning is printed with details
         ignore_upper_bands : int
             the first index of the upper bands to be ignored in the comparison (from 0 to NB-1), negative values count from the top (-4 means NB-4)
-        
+
         Returns
         -------
         float
             the maximum error
-        
+
         """
         maxerr = 0
         # for ik in range(self.NK):
@@ -585,7 +584,7 @@ class SymmetrizerSAWF:
                           f"   esym = {e2}\n"
                           f"   diff = {e1 - e2}\n")
                 maxerr = max(maxerr, maxerr_loc)
-                    
+
         return maxerr
 
     def check_amn(self, amn, warning_precision=1e-5,
@@ -708,7 +707,7 @@ class SymmetrizerSAWF:
 
 
 
-    def check_mmn(self, mmn, warning_precision=1e-5, ignore_upper_bands=-4, ignore_lower_bands=0):
+    def check_mmn(self, mmn, warning_precision=1e-5, ignore_upper_bands=-4, ignore_lower_bands=0, verbose=False):
         """
         Check the symmetry of data in the mmn file (not working)
 
@@ -724,14 +723,14 @@ class SymmetrizerSAWF:
         """
         assert mmn.NK == self.NK
         assert mmn.NB == self.NB
-        b1=ignore_lower_bands
-        b2=ignore_upper_bands
-    
+        b1 = ignore_lower_bands
+        b2 = ignore_upper_bands
+
 
         sym_product_table, translations_diff = self.spacegroup.get_product_table(get_translations_diff=True)
-        print("sym_product_table = \n ", sym_product_table)
-        print("translations_diff = \n ", translations_diff)
-    
+        # print("sym_product_table = \n ", sym_product_table)
+        # print("translations_diff = \n ", translations_diff)
+
         nnb = len(mmn.bk_latt)
         bk_latt = mmn.bk_latt
         bk_latt_transformed = np.array([[symop.transform_k(bk)  for bk in bk_latt] for symop in self.spacegroup.symmetries])
@@ -751,14 +750,14 @@ class SymmetrizerSAWF:
                 else:
                     raise ValueError(f"after applying symmetry operation{isym} to the bk vectors, none of the transformed vectors match the original vector {bk} ({ibk})\n"
                         f"b_k transformed = {bk_latt_transformed[isym]}\n")
-        print ("bk_latt_map = \n ", bk_latt_map)
+        # print ("bk_latt_map = \n ", bk_latt_map)
 
         translations_cart = np.array([symop.translation @ self.spacegroup.real_lattice for symop in self.spacegroup.symmetries])
-        print ("translations_cart = \n ", translations_cart)
-        print (f"bk_cart = \n {mmn.bk_cart}")
-        print( f"real_lattice = \n {self.spacegroup.real_lattice}")
+        # print ("translations_cart = \n ", translations_cart)
+        # print (f"bk_cart = \n {mmn.bk_cart}")
+        # print( f"real_lattice = \n {self.spacegroup.real_lattice}")
         kpoints_red = self.kpoints_all
-        
+
         checked = np.zeros((self.NK, nnb), dtype=bool)
 
         maxerr = 0
@@ -775,102 +774,108 @@ class SymmetrizerSAWF:
                 M = mmn.data[ik][ib]
                 for isym in range(self.Nsym):
                     M_loc = M.copy()
-                    
+
                     ik_sym = self.kptirr2kpt[ikirr, isym]
                     ib_sym = bk_latt_map[isym, ib]
-                    
+
                     if ikb in self.kptirr:
                         rblocks = self.d_band_blocks_inverse[ikbirr][isym]
-                        factor = np.exp(-1j*(mmn.bk_cart[ib_sym] @ translations_cart[isym]))
+                        factor = np.exp(-1j * (mmn.bk_cart[ib_sym] @ translations_cart[isym]))
                     else:
                         # continue
+
                         isym1 = self.kpt2kptirr_sym[ikb]
                         isym2 = sym_product_table[isym, isym1]
                         transl_diff = translations_diff[isym, isym1]
-                        # ation_difference = (self.spacegroup.symmetries[isym2].translation - 
-                        #     (self.spacegroup.symmetries[isym].multiply_keeptransl(self.spacegroup.symmetries[isym1])).translation)
-                        # translation_difference_cart = translation_difference @ self.spacegroup.real_lattice
-                        # if not np.allclose(translation_difference, 0):
+                        # if self.time_reversals[isym1] == self.time_reversals[isym2]:
                         #     continue
-                        # if has_translation[isym] or has_translation[isym1] or has_translation[isym2]:
-                        #     continue                            
-                        print(f"{ikbirr=} : original irreducible kpoint {kpoints_red[self.kptirr[ikbirr]]} (ibkirr={ikbirr}) ")
-                        print(f"transformed under isym={isym} ->     {self.kptirr2kpt[ikirr, isym]} = {kpoints_red[self.kptirr2kpt[ikbirr, isym]]} ")
-                        print(f"transformed under isym1={isym1} -> {self.kptirr2kpt[ikbirr, isym1]} = {kpoints_red[self.kptirr2kpt[ikbirr, isym1]]} ")
-                        print(f"transformed under isym2={isym2} -> {self.kptirr2kpt[ikbirr, isym2]} = {kpoints_red[self.kptirr2kpt[ikbirr, isym2]]} ")
-                        print(f"translation difference = {transl_diff} ")
-                        # if abs(kpoints_red[ik][2]) > 1e-5:
-                        #     continue
-                    
-                        print (f"isym1 = {isym1}, isym2 = {isym2}")
-                        rblocks = [d1 @ d2 for d1, d2 in zip(self.d_band_blocks[ikbirr][isym1], self.d_band_blocks_inverse[ikbirr][isym2] )]
-                        extra_factor = np.exp(2j*np.pi*(kpoints_red[self.kptirr2kpt[ikbirr, isym2]] @ transl_diff))
-                        factor = np.exp(-1j*(mmn.bk_cart[ib_sym] @ (translations_cart[isym] ))) 
-                        print (f"extra_factor = {extra_factor}, factor without it = {factor}")
-                        factor = factor*extra_factor
-                        # factor = np.exp(-1j*(mmn.bk_cart[ib_sym] @ translations_cart[isym2] - mmn.bk_cart[ib] @ translations_cart[isym1]))
 
+                        # print(f"{ikbirr=} : original irreducible kpoint {kpoints_red[self.kptirr[ikbirr]]} (ibkirr={ikbirr}) ")
+                        # print(f"transformed under isym={isym} ->     {self.kptirr2kpt[ikirr, isym]} = {kpoints_red[self.kptirr2kpt[ikbirr, isym]]} ")
+                        # print(f"transformed under isym1={isym1} -> {self.kptirr2kpt[ikbirr, isym1]} = {kpoints_red[self.kptirr2kpt[ikbirr, isym1]]} ")
+                        # print(f"transformed under isym2={isym2} -> {self.kptirr2kpt[ikbirr, isym2]} = {kpoints_red[self.kptirr2kpt[ikbirr, isym2]]} ")
+                        # print(f"translation difference = {transl_diff} ")
+
+                        # print (f"isym1 = {isym1}, isym2 = {isym2}")
+                        if self.time_reversals[isym]:
+                            # continue
+                            rblocks = [d1.conj() @ d2 for d1, d2 in zip(self.d_band_blocks[ikbirr][isym1], self.d_band_blocks_inverse[ikbirr][isym2])]
+                        else:
+                            rblocks = [d1 @ d2 for d1, d2 in zip(self.d_band_blocks[ikbirr][isym1], self.d_band_blocks_inverse[ikbirr][isym2])]
+                        # print (f"angles for d1 (isym1={isym1}) : {[np.angle(d.diagonal())/np.pi*180 for d in self.d_band_blocks[ikbirr][isym1][:2]]} ")
+                        # print (f"angles for d2 (isym2={isym2}) : {[np.angle(d.diagonal())/np.pi*180 for d in self.d_band_blocks_inverse[ikbirr][isym2][:2]]} ")
+                        # print (f"angles for rblocks            : {[np.angle(d.diagonal())/np.pi*180 for d in rblocks[:2]]} ")
+
+                        extra_factor = np.exp(2j * np.pi * (kpoints_red[self.kptirr2kpt[ikbirr, isym2]] @ transl_diff))
+                        factor = np.exp(-1j * (mmn.bk_cart[ib_sym] @ (translations_cart[isym])))
+                        # print (f"extra_factor = {extra_factor}, factor without it = {factor}")
+                        factor = factor * extra_factor
+                        # print (f"Time reversals isym[{isym}]={self.time_reversals[isym]}, isym1={isym1}={self.time_reversals[isym1]}, isym2={isym2}={self.time_reversals[isym2]} \n")
+
+                    # print (f"applying rblocks {rblocks[:2]} ")
                     checked[ik_sym, ib_sym] = True
 
-                    
+
                     if self.time_reversals[isym]:
                         M_loc = M_loc.conj()
-                        print (f"applying time-reversal for isym={isym} : \n {M[b1:b2, b1:b2]} \n -> \n {M_loc[b1:b2, b1:b2]}")
-                    
-                    
+                        # print (f"applying time-reversal for isym={isym} : \n {M[b1:b2, b1:b2]} \n -> \n {M_loc[b1:b2, b1:b2]}")
+
+
                     M_loc = rotate_block_matrix(M_loc,
                                    lblocks=self.d_band_blocks[ikirr][isym],
-                                   lindices=self.d_band_block_indices[ikirr] ,
+                                   lindices=self.d_band_block_indices[ikirr],
                                    rblocks=rblocks,
                                    rindices=rindices, )
 
-                    
-                    print (f"factor = {factor}")
-                    M_loc = M_loc*factor
+                    # print (f"factor = {factor}")
+                    M_loc = M_loc * factor
                     M_ref = mmn.data[ik_sym][ib_sym]
 
                     Mloc = M_loc[b1:b2, b1:b2]
                     Mref = M_ref[b1:b2, b1:b2]
                     Mmax = np.max([np.abs(Mloc), np.abs(Mref)], axis=0)
-                    diff_phase = (np.angle(Mloc) - np.angle(Mref))/np.pi*180 % 360
-                    diff_phase[diff_phase>355] -= 360
+                    diff_phase = (np.angle(Mloc) - np.angle(Mref)) / np.pi * 180 % 360
+                    diff_phase[diff_phase > 355] -= 360
                     diff_phase = diff_phase[Mmax > 1e-3]
-                    print (f"phase differences (degrees) for elements > 1e-3 in abs : \n {np.mean(diff_phase)} ")
+                    # print (f"Mloc_abs = \n {np.abs(Mloc)} \n Mref_abs = \n {np.abs(Mref)}")
+                    # print (f"Mloc_angle = \n {np.angle(Mloc)/np.pi*180} \n Mref_angle = \n {np.angle(Mref)/np.pi*180}")
+                    # print (f"phase differences (degrees) for elements > 1e-3 in abs : \n {diff_phase} ")
                     # if np.std(diff_phase) <1e-2:
                     #     continue
-                
+
 
                     # print (f"absolute values M_loc : \n {np.abs(M_loc[b1:b2, b1:b2])} \n reference : \n {np.abs(M_ref[b1:b2, b1:b2])}")
                     # print (f"angles (degrees) M_loc : \n {np.angle(M_loc[b1:b2, b1:b2])/np.pi*180} \n reference : \n {np.angle(M_ref[b1:b2, b1:b2])/np.pi*180}")
                     # print( f"difference in phases (degrees) : \n {((np.angle(M_loc[b1:b2, b1:b2]) - np.angle(M_ref[b1:b2, b1:b2]))/np.pi*180)  % 360} ")
 
 
-                    # print(f"applying blocks for isym={isym} : \n {self.d_band_blocks[ikirr][isym][:2]}\n and \n {self.d_band_blocks_inverse[ikbirr][isym][:2]}") 
+                    # print(f"applying blocks for isym={isym} : \n {self.d_band_blocks[ikirr][isym][:2]}\n and \n {self.d_band_blocks_inverse[ikbirr][isym][:2]}")
                     # print (f"after rotation for isym={isym} : \n {M[b1:b2, b1:b2]} \n -> \n {M_loc[b1:b2, b1:b2]}")
 
                     # print (f"reference isym={isym}, ik_sym={ik_sym}, ib_sym={ib_sym} : \n {M_ref[b1:b2, b1:b2]}")
                     diff = np.abs(M_loc[b1:b2, b1:b2] - M_ref[b1:b2, b1:b2])
                     err = np.max(diff)
-                    print (f"transition {kpoints_red[ik]}->{kpoints_red[ikb]} under symmetry {isym} -> {self.spacegroup.symmetries[isym]} \n"
-                           f"transition {kpoints_red[ik_sym]}->{kpoints_red[mmn.neighbours[ik_sym][ib_sym]]} \n")
+                    # print (f"transition {kpoints_red[ik]}->{kpoints_red[ikb]} under symmetry {isym} -> {self.spacegroup.symmetries[isym]} \n"
+                    #        f"transition {kpoints_red[ik_sym]}->{kpoints_red[mmn.neighbours[ik_sym][ib_sym]]} \n")
 
-                    print(("CORRECT :" if err < warning_precision else "ERROR   :") + 
-                          f"ikirr={ikirr}, ik={self.kptirr[ikirr]}, ib={ib}, ikb={ikb}, isym={isym}, iksym={ik_sym}, ibsym={ib_sym} : err = {err}" +
-                         f"G[ {ik},{ib}] = {mmn.G[ik][ib]}, G[{ik_sym},{ib_sym}] = {mmn.G[ik_sym][ib_sym]} "
-                          )
-                    if err > warning_precision:
-                        A = np.round(np.log(np.abs(diff))/np.log(10), 0).astype(int)
-                        print("\n".join(" ".join(f"{a:3d}" for a in row) for row in A))
-                        
+                    if err > warning_precision or verbose:
+                        print(("CORRECT :" if err < warning_precision else "ERROR   :") +
+                              f"ikirr={ikirr}, ik={self.kptirr[ikirr]}, ib={ib}, ikb={ikb}, isym={isym}, iksym={ik_sym}, ibsym={ib_sym} : err = {err}"
+                              # + f"G[ {ik},{ib}] = {mmn.G[ik][ib]}, G[{ik_sym},{ib_sym}] = {mmn.G[ik_sym][ib_sym]} "
+                                )
+                        # if verbose:
+                        #     A = np.round(np.log(np.abs(diff))/np.log(10), 0).astype(int)
+                        #     print("\n".join(" ".join(f"{a:3d}" for a in row) for row in A))
 
-                    maxerr = max(maxerr, err)     
+
+                    maxerr = max(maxerr, err)
         print(f"checked = {sum(checked.flatten())} out of {checked.size} elements")
-        print (f"not checked elements (should be zero) = \n {np.where(~checked)}")
-        return maxerr                   
-                
-            
-            
-            
+        print(f"not checked elements (should be zero) = \n {np.where(~checked)}")
+        return maxerr
+
+
+
+
         #     kirr1 = self.kptirr[ikirr]
         #     neigh_irr = neighbours_irr[ind1]
         #     for j in range(self.NKirr):

--- a/wannierberri/symmetry/sawf.py
+++ b/wannierberri/symmetry/sawf.py
@@ -242,7 +242,7 @@ class SymmetrizerSAWF:
             self.rot_orb_list.append(_Dwann.rot_orb)
         self.set_D_wann(D_wann_list)
         return self
-    
+
     def set_upper_block_to_zero(self):
         """
         Sets the upper block of the d_band matrices to zero, to avoid problems with imcomplete irreps
@@ -650,12 +650,12 @@ class SymmetrizerSAWF:
                 diff = np.max(abs(diff))
                 maxerr = max(maxerr, np.linalg.norm(diff))
                 if diff > warning_precision:
-                    print(f"ikirr={ikirr}, isym={isym} kpt  {self.kptirr[ikirr]}-> {ik}: {diff}")
+                    print(f"ikirr={ikirr}, isym={isym} kpt  {ik_origin} -> {ik_rotated}: {diff}")
                     if verbose:
                         print(f"   a1  = \n{arr_to_string(a1)}")
                         print(f"   a1' = \n{arr_to_string(a1p)}")
                         print(f"   a2  = \n{arr_to_string(a2)}")
-                        
+
         return maxerr
 
     def symmetrize_amn(self, amn):

--- a/wannierberri/symmetry/sawf.py
+++ b/wannierberri/symmetry/sawf.py
@@ -153,7 +153,7 @@ class SymmetrizerSAWF:
         self.clear_inverse()
         if store_eig:
             self.set_eig([bandstructure.kpoints[ik].Energy_raw for ik in self.kptirr])
-        self.set_upper_block_to_zero()
+        # self.set_upper_block_to_zero()
         return self
 
     @cached_property
@@ -243,15 +243,15 @@ class SymmetrizerSAWF:
         self.set_D_wann(D_wann_list)
         return self
 
-    def set_upper_block_to_zero(self):
-        """
-        Sets the upper block of the d_band matrices to zero, to avoid problems with imcomplete irreps
-        """
-        for ikirr in range(self.NKirr):
-            for isym in range(self.Nsym):
-                blocks = self.d_band_blocks[ikirr][isym]
-                blocks[-1][:, :] = 0.0
-        self.clear_inverse(d=True, D=False)
+    # def set_upper_block_to_zero(self):
+    #     """
+    #     Sets the upper block of the d_band matrices to zero, to avoid problems with imcomplete irreps
+    #     """
+    #     for ikirr in range(self.NKirr):
+    #         for isym in range(self.Nsym):
+    #             blocks = self.d_band_blocks[ikirr][isym]
+    #             blocks[-1][:, :] = 0.0
+    #     self.clear_inverse(d=True, D=False)
 
     @cached_property
     def rot_orb_dagger_list(self):

--- a/wannierberri/symmetry/sawf.py
+++ b/wannierberri/symmetry/sawf.py
@@ -153,7 +153,6 @@ class SymmetrizerSAWF:
         self.clear_inverse()
         if store_eig:
             self.set_eig([bandstructure.kpoints[ik].Energy_raw for ik in self.kptirr])
-        # self.set_upper_block_to_zero()
         return self
 
     @cached_property
@@ -242,16 +241,6 @@ class SymmetrizerSAWF:
             self.rot_orb_list.append(_Dwann.rot_orb)
         self.set_D_wann(D_wann_list)
         return self
-
-    # def set_upper_block_to_zero(self):
-    #     """
-    #     Sets the upper block of the d_band matrices to zero, to avoid problems with imcomplete irreps
-    #     """
-    #     for ikirr in range(self.NKirr):
-    #         for isym in range(self.Nsym):
-    #             blocks = self.d_band_blocks[ikirr][isym]
-    #             blocks[-1][:, :] = 0.0
-    #     self.clear_inverse(d=True, D=False)
 
     @cached_property
     def rot_orb_dagger_list(self):
@@ -581,12 +570,6 @@ class SymmetrizerSAWF:
 
         """
         maxerr = 0
-        # for ik in range(self.NK):
-        #     ikirr = self.kpt2kptirr[ik]
-        #     e1 = eig.data[ik]
-        #     e2 = eig.data[self.kptirr[ikirr]]
-        #     maxerr = max(maxerr, np.linalg.norm(e1 - e2))
-
         for ikirr in range(self.NKirr):
             for isym in range(self.Nsym):
                 e1 = eig.data[self.kptirr[ikirr]][:ignore_upper_bands]
@@ -598,7 +581,6 @@ class SymmetrizerSAWF:
                           f"   esym = {e2}\n"
                           f"   diff = {e1 - e2}\n")
                 maxerr = max(maxerr, maxerr_loc)
-
         return maxerr
 
     def check_amn(self, amn, warning_precision=1e-5,
@@ -689,18 +671,6 @@ class SymmetrizerSAWF:
             amn_sym_irr[ikirr] /= len(self.isym_little[ikirr])
         # now expand to the full BZ
         return self.U_to_full_BZ(amn_sym_irr)
-        # lfound = np.zeros(self.NK, dtype=bool)
-        # amn_sym = np.zeros((self.NK, self.NB, self.num_wann), dtype=complex)
-        # for ikirr in range(self.NKirr):
-        #     ik = self.kptirr[ikirr]
-        #     amn_sym[ik] = amn_sym_irr[ikirr]
-        #     lfound[ik] = True
-        #     for isym in range(self.Nsym):
-        #         ik = self.kptirr2kpt[ikirr, isym]
-        #         if not lfound[ik]:
-        #             amn_sym[ik] = self.rotate_U(amn_sym_irr[ikirr], ikirr, isym, forward=True)
-        #             lfound[ik] = True
-        # return amn_sym
 
     def get_random_amn(self):
         """ generate a random amn array that is comaptible with the symmetries of the Wanier functions in thesymmetrizer object

--- a/wannierberri/symmetry/sawf_kirr.py
+++ b/wannierberri/symmetry/sawf_kirr.py
@@ -1,5 +1,5 @@
 import numpy as np
-from ..utility import orthogonalize, arr_to_string
+from ..utility import orthogonalize
 from .utility import get_inverse_block, rotate_block_matrix
 from .sawf import SymmetrizerSAWF, VoidSymmetrizer
 
@@ -36,15 +36,15 @@ class Symmetrizer_Uirr(SymmetrizerSAWF):
         self.nb = symmetrizer.NB
         self.num_wann = symmetrizer.num_wann
         self.time_reversals = symmetrizer.time_reversals
-        self.symop_product, self.symop_diff, self.spinor_diff = symmetrizer.spacegroup.get_product_table(get_diff=True)
-        print(f"initializing Symmetrizer_Uirr for ikirr={ikirr}, ikpt={self.ikpt}, {self.kpt_latt} with {self.nsym_little} symmetries")
+        # self.symop_product, self.symop_diff, self.spinor_diff = symmetrizer.spacegroup.get_product_table(get_diff=True)
+        # print(f"initializing Symmetrizer_Uirr for ikirr={ikirr}, ikpt={self.ikpt}, {self.kpt_latt} with {self.nsym_little} symmetries")
         # print(f" product table:\n{ "\n".join([ " ".join([f'{self.symop_product[i,j]:3d}' for j in self.isym_little]) for i in self.isym_little]) }")
         # self.check_products_d()
         # self.check_products_D()
         # self.check_products_dD()
         err = self.check()
-        print (f"Symmetrizer_Uirr initialized for ikirr={ikirr}, kpt={self.ikpt}, {self.kpt_latt} with {self.nsym_little} symmetries, max error in check: {err}")
-    
+        print(f"Symmetrizer_Uirr initialized for ikirr={ikirr}, kpt={self.ikpt}, {self.kpt_latt} with {self.nsym_little} symmetries, max error in check: {err}")
+
 
     # def check_products_d(self):
     #     maxerr = 0.0
@@ -80,31 +80,31 @@ class Symmetrizer_Uirr(SymmetrizerSAWF):
     #                 if err > 1e-6:
     #                     print(f"Warning: product of D matrices does not match for isym1={isym1}, isym2={isym2}, isym3={isym3}, block {i} (of {len(self.D_indices)}) [{start}:{end}]: {err}")
     #                     print(f"D1 = {D1}, D2={D2}, D2@D1={prod} D3={D3},")
-    #     print (f"max error in D products: {maxerr}")
+    # #     print (f"max error in D products: {maxerr}")
 
-    def check_products_dD(self, U=None):
-        if U is None:
-            U = np.random.rand(self.nb, self.num_wann) + 1j * np.random.rand(self.nb, self.num_wann)
-        maxerr = 0.0
-        max_index = self.d_indices[-2][1]
-        for isym1 in self.isym_little:
-            for isym2 in self.isym_little:
-                isym3 = self.symop_product[isym1, isym2]
-                assert isym3 in self.isym_little, f"Error: product of two little group symmetries {isym1}, {isym2} gives {isym3} which is not in the little group"
-                U1 = self.rotate_U(U, isym2)
-                U2 = self.rotate_U(U1, isym1)
-                U3 = self.rotate_U(U, isym3)
-                err = np.linalg.norm(U2[:max_index] - U3[:max_index])
-                maxerr = max(maxerr, err)
-                if err > 1e-6:
-                    print(f"Warning: product of d and D matrices does not match for isym1={isym1}, isym2={isym2}, isym3={isym3}: {err}")
-                else:
-                    pass
-                    # print (f"applying {isym2}, then {isym1} gives the same result as applying {isym3} directly, error {err}")
-        return maxerr
-        # print (f"max error in dD products: {maxerr}")
+    # def check_products_dD(self, U=None):
+    #     if U is None:
+    #         U = np.random.rand(self.nb, self.num_wann) + 1j * np.random.rand(self.nb, self.num_wann)
+    #     maxerr = 0.0
+    #     max_index = self.d_indices[-2][1]
+    #     for isym1 in self.isym_little:
+    #         for isym2 in self.isym_little:
+    #             isym3 = self.symop_product[isym1, isym2]
+    #             assert isym3 in self.isym_little, f"Error: product of two little group symmetries {isym1}, {isym2} gives {isym3} which is not in the little group"
+    #             U1 = self.rotate_U(U, isym2)
+    #             U2 = self.rotate_U(U1, isym1)
+    #             U3 = self.rotate_U(U, isym3)
+    #             err = np.linalg.norm(U2[:max_index] - U3[:max_index])
+    #             maxerr = max(maxerr, err)
+    #             if err > 1e-6:
+    #                 print(f"Warning: product of d and D matrices does not match for isym1={isym1}, isym2={isym2}, isym3={isym3}: {err}")
+    #             else:
+    #                 pass
+    #                 # print (f"applying {isym2}, then {isym1} gives the same result as applying {isym3} directly, error {err}")
+    #     return maxerr
+    #     # print (f"max error in dD products: {maxerr}")
 
-                
+
     def check(self, U=None, warning_precision=1e-6, verbose=False):
         """
         Checks that the symmetrization is correct by comparing eig at the
@@ -128,7 +128,7 @@ class Symmetrizer_Uirr(SymmetrizerSAWF):
         maxerr = 0.0
         U = self(U)  # symmetrize U
         # U = sum(self.rotate_U(U, isym) for isym in self.isym_little)
-        upper_bands = self.d_indices[-2][1] 
+        upper_bands = self.d_indices[-2][1]
         # print (f"symmetrized U matrix for check: \n{arr_to_string(U, fmt='{:12.5e}')}")
         for isym in self.isym_little:
             U1 = self.rotate_U(U, isym)
@@ -161,7 +161,7 @@ class Symmetrizer_Uirr(SymmetrizerSAWF):
         return Uloc
 
 
-    def __call__(self, U, maxiter=100, tol=1e-8):
+    def __call__(self, U, maxiter=100, tol=1e-6):
         Uprev = U.copy()
         for i in range(maxiter):
             Uloc = Uprev.copy()
@@ -171,13 +171,14 @@ class Symmetrizer_Uirr(SymmetrizerSAWF):
             Usym_ortho[:self.max_band] = orthogonalize(Usym[:self.max_band])
             diff2 = abs(Usym_ortho - Usym).max()
             if diff1 < tol and diff2 < tol:
-                # print(f"Symmetrization converged in {i+1} iterations")  
+                # print(f"Symmetrization converged in {i+1} iterations")
                 return Usym
             Uprev = Usym_ortho
         else:
             print(f"Warning: symmetrization did not converge in {maxiter} iterations, final changes {diff1}, {diff2}")
             return Usym
-        
+
+
 class Symmetrizer_Zirr(SymmetrizerSAWF):
 
     def __init__(self, symmetrizer, ikirr, free):

--- a/wannierberri/symmetry/sym_wann_2.py
+++ b/wannierberri/symmetry/sym_wann_2.py
@@ -60,6 +60,7 @@ class SymWann:
             iRvec,
             wannier_centers_cart=None,
             silent=False,
+            use_symmetries_index = None,
     ):
 
         self.silent = silent
@@ -70,6 +71,10 @@ class SymWann:
         self.num_wann = symmetrizer.num_wann
         self.spacegroup = symmetrizer.spacegroup
         self.lattice = self.spacegroup.lattice
+        if use_symmetries_index is None:
+            self.use_symmetries_index = list(range(len(self.spacegroup.symmetries)))
+        else:
+            self.use_symmetries_index = use_symmetries_index
 
         self.symmetrizer = symmetrizer
         self.num_blocks = len(symmetrizer.D_wann_block_indices)
@@ -79,7 +84,6 @@ class SymWann:
         points_index = np.cumsum([0] + self.num_points_list)
         self.points_index_start = points_index[:-1]
         self.points_index_end = points_index[1:]
-
         self.possible_matrix_list = ['Ham', 'AA', 'SS', 'BB', 'CC', 'AA', 'BB', 'CC', 'OO', 'GG',
                                 'SS', 'SA', 'SHA', 'SR', 'SH', 'SHR']
         self.tested_matrix_list = ['Ham', 'AA', 'SS', 'BB', 'CC', 'AA', 'BB', 'CC',
@@ -157,9 +161,9 @@ class SymWann:
 
         R_list = np.array(self.iRvec, dtype=int)
         logfile.write(f"R_list = {R_list}\n")
-        R_map = [np.dot(R_list, np.transpose(symop.rotation)) for symop in self.spacegroup.symmetries]
+        R_map = [(R_list @ symop.rotation.T) for symop in self.spacegroup.symmetries]
 
-        for isym in range(self.symmetrizer.Nsym):
+        for isym in self.use_symmetries_index:
             T1 = self.symmetrizer.T_list[block1][:, isym]
             T2 = self.symmetrizer.T_list[block2][:, isym]
             logfile.write(f"symmetry operation  {isym + 1}/{len(self.spacegroup.symmetries)}\n")
@@ -197,6 +201,15 @@ class SymWann:
         """
         Symmetrize wannier matrices in real space: Ham_R, AA_R, BB_R, SS_R,...
         and find the new R vectors
+
+        Parameters
+        ----------
+        XX_R: dict {str: np.array(nRvec, num_wann, num_wann, ...), dtype=complex}
+            Matrices to be symmetrized.
+        cutoff: float
+            Cutoff for small matrix elements in XX_R.   
+        cutoff_dict: dict {str: float}
+            Cutoff for small matrix elements in XX_R for each matrix type.
 
         Returns
         --------
@@ -244,12 +257,17 @@ class SymWann:
                 matrix_dict_list = {}
                 for k, v1 in XX_R.items():
                     v = np.copy(v1)[:, ws1:we1, ws2:we2]
+
+                    # transforms a matrix X[iR, m,n,...] into a nested dictionary like
+                    # {(a,b): {iR: np.array(num_w_a, num_w_b,...)}}
                     matrix_dict_list[k] = _matrix_to_dict(v, np1=np1, norb1=norb1, np2=np2, norb2=norb2,
                                                           cutoff=cutoff_dict[k])
+                    
                 matrix_dict_list_res, iRvec_ab_all = self.average_XX_block(iRab_new=iRab_irred,
                                                                         matrix_dict_in=matrix_dict_list,
-                                                                        iRvec_new=self.iRvec, mode="sum",
-                                                                        block1=block1, block2=block2)
+                                                                        iRvec_origin=self.iRvec, mode="sum",
+                                                                        block1=block1, block2=block2,
+                                                                        forward=True)
 
                 iRvec_new_set = set.union(*iRvec_ab_all.values())
                 iRvec_new_set.add((0, 0, 0))
@@ -259,8 +277,9 @@ class SymWann:
                 iRab_new = {k: set([iRvec_new_index[irvec] for irvec in v]) for k, v in iRvec_ab_all.items()}
                 matrix_dict_list_res, iRab_all_2 = self.average_XX_block(iRab_new=iRab_new,
                                                                          matrix_dict_in=matrix_dict_list_res,
-                                                                         iRvec_new=iRvec_new, mode="single",
-                                                                         block1=block1, block2=block2)
+                                                                         iRvec_origin=iRvec_new, mode="single",
+                                                                         block1=block1, block2=block2,
+                                                                         forward=True)
 
                 full_matrix_dict_list[(block1, block2)] = matrix_dict_list_res
                 full_iRvec_list[(block1, block2)] = iRvec_new
@@ -303,8 +322,31 @@ class SymWann:
         return return_dic, np.array(iRvec_new), wcc
 
 
-    def average_XX_block(self, iRab_new, matrix_dict_in, iRvec_new, mode, block1, block2):
+    def average_XX_block(self, iRab_new, matrix_dict_in, iRvec_origin, mode, block1, block2, forward=True):
         """
+        Averages matrices over symmetry operations for a given pair of blocks.
+
+        Parameters
+        ----------
+        iRab_new : dict
+            A dictionary mapping (atom_a, atom_b) pairs to lists of new R-vectors (That need to be evaluated)
+
+        matrix_dict_in : dict
+            A dictionary containing the input matrices to be averaged.
+
+        iRvec_origin : list
+            A list of original R-vectors.
+
+        mode : str
+            The averaging mode, either "sum" or "single". In sum mode all R-vectors that map to the same R-vector are summed.
+            In sungle mode only one of them is taken.
+
+        block1 : int
+            The index of the first block.
+
+        block2 : int
+            The index of the second block.
+
         Return
         --------
             (matrix_dict_list_res, iRab_all)
@@ -313,21 +355,24 @@ class SymWann:
         """
         assert mode in ["sum", "single"]
         iRab_new = copy.deepcopy(iRab_new)
-        iRvec_new_array = np.array(iRvec_new, dtype=int)
+        iRvec_origin_array = np.array(iRvec_origin, dtype=int)
 
         matrix_dict_list_res = {k: defaultdict(lambda: defaultdict(lambda: 0)) for k in matrix_dict_in}
 
         iRab_all = defaultdict(lambda: set())
         logfile = self.logfile
 
-        for isym, symop in enumerate(self.spacegroup.symmetries):
+        for isym in self.use_symmetries_index:
+            symop = self.spacegroup.symmetries[isym]
+            # T is the translation needed to return to the home unit cell after rotation
             T1 = self.symmetrizer.T_list[block1][:, isym]
             T2 = self.symmetrizer.T_list[block2][:, isym]
             atommap1 = self.symmetrizer.atommap_list[block1][:, isym]
             atommap2 = self.symmetrizer.atommap_list[block2][:, isym]
             logfile.write(f"symmetry operation  {isym + 1}/{len(self.spacegroup.symmetries)}")
-            R_map = iRvec_new_array @ np.transpose(symop.rotation)
+            R_map = iRvec_origin_array @ symop.rotation.T
             atom_R_map = (R_map[:, None, None, :] + T1[None, :, None, :] - T2[None, None, :, :])
+            # atom_R_map[iR, a, b] gives the new R vector to wich the original iR vector is mapped for atoms a and b
             for (atom_a, atom_b), iR_new_list in iRab_new.items():
                 atom_a_map = atommap1[atom_a]
                 atom_b_map = atommap2[atom_b]
@@ -342,29 +387,28 @@ class SymWann:
                                 if mode == "single":
                                     exclude_set.add(iR)
                                 # X_L: only rotation wannier centres from L to L' before rotating orbitals.
-                                XX_L = matrix_dict_in[X][(atom_a_map, atom_b_map)][
-                                    new_Rvec_index]
+                                XX_L = matrix_dict_in[X][(atom_a_map, atom_b_map)][new_Rvec_index]
                                 matrix_dict_list_res[X][(atom_a, atom_b)][iR] += self._rotate_XX_L(
-                                    XX_L, X, isym, block1=block1, block2=block2, atom_a=atom_a_map, atom_b=atom_b_map)
+                                    XX_L, X, isym, block1=block1, block2=block2, atom_a=atom_a_map, atom_b=atom_b_map, forward=forward)
+                                    
                 # in single mode we need to determine it only once
                 if mode == "single":
                     iR_new_list -= exclude_set
 
-        if mode == "single":
-            for (atom_a, atom_b), iR_new_list in iRab_new.items():
-                assert len(
-                    iR_new_list) == 0, f"for atoms ({atom_a},{atom_b}) some R vectors were not set : {iR_new_list}" + ", ".join(
-                    str(iRvec_new[ir]) for ir in iR_new_list)
+        # if mode == "single":
+        #     for (atom_a, atom_b), iR_new_list in iRab_new.items():
+        #         assert len(iR_new_list) == 0, f"for atoms ({atom_a},{atom_b}) some R vectors were not set : {iR_new_list}" + ", ".join(
+        #             str(iRvec_origin[ir]) for ir in iR_new_list)
 
         if mode == "sum":
             for x in matrix_dict_list_res.values():
                 for d in x.values():
                     for k, v in d.items():
-                        v /= self.spacegroup.size
+                        v /= len(self.use_symmetries_index)
         return matrix_dict_list_res, iRab_all
 
 
-    def _rotate_XX_L(self, XX_L: np.ndarray, X: str, isym, block1, block2, atom_a, atom_b):
+    def _rotate_XX_L(self, XX_L: np.ndarray, X: str, isym, block1, block2, atom_a, atom_b, forward=True):
         """
         H_ab_sym = P_dagger_a dot H_ab dot P_b
         H_ab_sym_T = ul dot H_ab_sym.conj() dot ur
@@ -394,7 +438,10 @@ class SymWann:
             XX_L = np.tensordot(XX_L, symop.rotation_cart, axes=((-n_cart,), (0,)))
         if symop.inversion:
             XX_L *= self.parity_I[X] * (-1)**n_cart
-        result = _rotate_matrix(XX_L, self.symmetrizer.rot_orb_dagger_list[block1][atom_a, isym], self.symmetrizer.rot_orb_list[block2][atom_b, isym])
+        if forward:
+            result = _rotate_matrix(XX_L, self.symmetrizer.rot_orb_dagger_list[block1][atom_a, isym], self.symmetrizer.rot_orb_list[block2][atom_b, isym])
+        else:
+            result = _rotate_matrix(XX_L, self.symmetrizer.rot_orb_list[block1][atom_a, isym], self.symmetrizer.rot_orb_dagger_list[block2][atom_b, isym])
         if symop.time_reversal:
             result = result.conj() * self.parity_TR[X]
         return result
@@ -426,8 +473,8 @@ def test_rotate_matrix():
 
 
 def _matrix_to_dict(mat, np1, norb1, np2, norb2, cutoff=1e-10):
-    """transforms a matrix X[iR, m,n,...] into a dictionary like
-        {(a,b): {iR: np.array(num_w_a.num_w_b,...)}}
+    """transforms a matrix X[iR, m,n,...] into a nested dictionary like
+        {(a,b): {iR: np.array(num_w_a, num_w_b,...)}}
     """
     result = defaultdict(lambda: {})
     for a in range(np1):

--- a/wannierberri/symmetry/sym_wann_2.py
+++ b/wannierberri/symmetry/sym_wann_2.py
@@ -60,7 +60,7 @@ class SymWann:
             iRvec,
             wannier_centers_cart=None,
             silent=False,
-            use_symmetries_index = None,
+            use_symmetries_index=None,
     ):
 
         self.silent = silent
@@ -262,7 +262,7 @@ class SymWann:
                     # {(a,b): {iR: np.array(num_w_a, num_w_b,...)}}
                     matrix_dict_list[k] = _matrix_to_dict(v, np1=np1, norb1=norb1, np2=np2, norb2=norb2,
                                                           cutoff=cutoff_dict[k])
-                    
+
                 matrix_dict_list_res, iRvec_ab_all = self.average_XX_block(iRab_new=iRab_irred,
                                                                         matrix_dict_in=matrix_dict_list,
                                                                         iRvec_origin=self.iRvec, mode="sum",
@@ -390,7 +390,7 @@ class SymWann:
                                 XX_L = matrix_dict_in[X][(atom_a_map, atom_b_map)][new_Rvec_index]
                                 matrix_dict_list_res[X][(atom_a, atom_b)][iR] += self._rotate_XX_L(
                                     XX_L, X, isym, block1=block1, block2=block2, atom_a=atom_a_map, atom_b=atom_b_map, forward=forward)
-                                    
+
                 # in single mode we need to determine it only once
                 if mode == "single":
                     iR_new_list -= exclude_set

--- a/wannierberri/symmetry/utility.py
+++ b/wannierberri/symmetry/utility.py
@@ -86,5 +86,3 @@ def get_inverse_block(D):
             return np.linalg.inv(D)
     else:
         raise ValueError(f"Unknown type {type(D)}")
-
-

--- a/wannierberri/symmetry/utility.py
+++ b/wannierberri/symmetry/utility.py
@@ -3,7 +3,6 @@ import numpy as np
 
 
 def rotate_block_matrix(Z, lblocks, lindices, rblocks, rindices,
-                        # inv_left, inv_right,
                         result=None):
     """
     Rotates the matrix Z using the block-diagonal rotation matrices
@@ -81,6 +80,11 @@ def get_inverse_block(D):
     if isinstance(D, list):
         return [get_inverse_block(d) for d in D]
     elif isinstance(D, np.ndarray):
-        return np.linalg.inv(D)
+        if abs(D).max() < 1e-8:
+            return np.zeros(D.shape, dtype=D.dtype)
+        else:
+            return np.linalg.inv(D)
     else:
         raise ValueError(f"Unknown type {type(D)}")
+
+

--- a/wannierberri/system/system.py
+++ b/wannierberri/system/system.py
@@ -145,7 +145,7 @@ class System:
         self.set_pointgroup(symmetry_gen=symmetry_gen, pointgroup=pointgroup, spacegroup=spacegroup)
 
 
-    def set_pointgroup(self, symmetry_gen=(), pointgroup=None, spacegroup=None):
+    def set_pointgroup(self, symmetry_gen=(), pointgroup=None, spacegroup=None, use_symmetries_index=None):
         """
         Set the symmetry group of the :class:`System`, which will be used for symmetrization
         in k-space and for reducing the number of k-points in the BZ.
@@ -173,7 +173,7 @@ class System:
             self.pointgroup = pointgroup
         elif spacegroup is not None:
             assert np.allclose(spacegroup.Lattice, self.real_lattice), f"the provided spacegroup has a different real_lattice:\n{spacegroup.Lattice}\n than the system:\n{self.real_lattice}"
-            self.pointgroup = PointGroup(spacegroup=spacegroup, recip_lattice=self.recip_lattice, real_lattice=self.real_lattice)
+            self.pointgroup = PointGroup(spacegroup=spacegroup, recip_lattice=self.recip_lattice, real_lattice=self.real_lattice, use_symmetries_index=use_symmetries_index)
         else:
             self.pointgroup = PointGroup(symmetry_gen, recip_lattice=self.recip_lattice, real_lattice=self.real_lattice)
 

--- a/wannierberri/system/system.py
+++ b/wannierberri/system/system.py
@@ -169,9 +169,10 @@ class System:
         + Only the **point group** operations are important. Hence, for non-symmorphic operations, only the rotational part should be given, neglecting the translation.
         """
         if pointgroup is not None:
+            assert np.allclose(pointgroup.recip_lattice, self.recip_lattice), f"the provided pointgroup has a different recip_lattice:\n{pointgroup.recip_lattice}\n than the system:\n{self.recip_lattice}"
             self.pointgroup = pointgroup
         elif spacegroup is not None:
-            assert np.allclose(spacegroup.Lattice, self.real_lattice)
+            assert np.allclose(spacegroup.Lattice, self.real_lattice), f"the provided spacegroup has a different real_lattice:\n{spacegroup.Lattice}\n than the system:\n{self.real_lattice}"
             self.pointgroup = PointGroup(spacegroup=spacegroup, recip_lattice=self.recip_lattice, real_lattice=self.real_lattice)
         else:
             self.pointgroup = PointGroup(symmetry_gen, recip_lattice=self.recip_lattice, real_lattice=self.real_lattice)

--- a/wannierberri/system/system_R.py
+++ b/wannierberri/system/system_R.py
@@ -240,7 +240,8 @@ class System_R(System):
     def Ham_R(self):
         return self.get_R_mat('Ham')
 
-    def symmetrize2(self, symmetrizer, silent=True):
+    def symmetrize2(self, symmetrizer, silent=True, use_symmetries_index = None, 
+                    cutoff=-1, cutoff_dict=None):
         """
         Symmetrize the system according to the Symmetrizer object.
 
@@ -250,6 +251,8 @@ class System_R(System):
             The symmetrizer object that will be used for symmetrization. (make sure it is consistent with the order of projections)
         silent : bool
             If True, do not print the symmetrization process. (set to False to see more debug information)
+        use_symmetries_index : list of int
+            List of symmetry indices to use for symmetrization. If None, all symmetries will be used.
         """
         from ..symmetry.sym_wann_2 import SymWann
         symmetrize_wann = SymWann(
@@ -257,6 +260,7 @@ class System_R(System):
             iRvec=self.rvec.iRvec,
             wannier_centers_cart=self.wannier_centers_cart,
             silent=self.silent or silent,
+            use_symmetries_index = use_symmetries_index,
         )
 
         # self.check_AA_diag_zero(msg="before symmetrization", set_zero=True)
@@ -266,14 +270,15 @@ class System_R(System):
             logfile.write(f"Wannier Centers cart (raw):\n {self.wannier_centers_cart}\n")
             logfile.write(f"Wannier Centers red: (raw):\n {self.wannier_centers_red}\n")
 
-        self._XX_R, iRvec, self.wannier_centers_cart = symmetrize_wann.symmetrize(XX_R=self._XX_R)
+        self._XX_R, iRvec, self.wannier_centers_cart = symmetrize_wann.symmetrize(XX_R=self._XX_R, 
+                                                                                  cutoff=cutoff, cutoff_dict=cutoff_dict)
         self.clear_cached_wcc()
         self.rvec = Rvectors(
             lattice=self.real_lattice,
             iRvec=iRvec,
             shifts_left_red=self.wannier_centers_red,
         )
-        self.set_pointgroup(spacegroup=symmetrizer.spacegroup)
+        self.set_pointgroup(spacegroup=symmetrizer.spacegroup, use_symmetries_index = use_symmetries_index)
 
         if not silent:
             logfile.write(f"Wannier Centers cart (symetrized):\n {self.wannier_centers_cart}\n")

--- a/wannierberri/system/system_R.py
+++ b/wannierberri/system/system_R.py
@@ -883,6 +883,8 @@ class System_R(System):
                                      iRvec=val,
                                      shifts_left_red=self.wannier_centers_red
                                      )
+            elif "key" == "pointgroup":
+                self.set_pointgroup(pointgroup=val)
             else:
                 setattr(self, key_loc, val)
             logfile.write(" - Ok!\n")

--- a/wannierberri/system/system_R.py
+++ b/wannierberri/system/system_R.py
@@ -240,7 +240,7 @@ class System_R(System):
     def Ham_R(self):
         return self.get_R_mat('Ham')
 
-    def symmetrize2(self, symmetrizer, silent=True, use_symmetries_index = None, 
+    def symmetrize2(self, symmetrizer, silent=True, use_symmetries_index=None,
                     cutoff=-1, cutoff_dict=None):
         """
         Symmetrize the system according to the Symmetrizer object.
@@ -260,7 +260,7 @@ class System_R(System):
             iRvec=self.rvec.iRvec,
             wannier_centers_cart=self.wannier_centers_cart,
             silent=self.silent or silent,
-            use_symmetries_index = use_symmetries_index,
+            use_symmetries_index=use_symmetries_index,
         )
 
         # self.check_AA_diag_zero(msg="before symmetrization", set_zero=True)
@@ -270,7 +270,7 @@ class System_R(System):
             logfile.write(f"Wannier Centers cart (raw):\n {self.wannier_centers_cart}\n")
             logfile.write(f"Wannier Centers red: (raw):\n {self.wannier_centers_red}\n")
 
-        self._XX_R, iRvec, self.wannier_centers_cart = symmetrize_wann.symmetrize(XX_R=self._XX_R, 
+        self._XX_R, iRvec, self.wannier_centers_cart = symmetrize_wann.symmetrize(XX_R=self._XX_R,
                                                                                   cutoff=cutoff, cutoff_dict=cutoff_dict)
         self.clear_cached_wcc()
         self.rvec = Rvectors(
@@ -278,7 +278,7 @@ class System_R(System):
             iRvec=iRvec,
             shifts_left_red=self.wannier_centers_red,
         )
-        self.set_pointgroup(spacegroup=symmetrizer.spacegroup, use_symmetries_index = use_symmetries_index)
+        self.set_pointgroup(spacegroup=symmetrizer.spacegroup, use_symmetries_index=use_symmetries_index)
 
         if not silent:
             logfile.write(f"Wannier Centers cart (symetrized):\n {self.wannier_centers_cart}\n")

--- a/wannierberri/utility.py
+++ b/wannierberri/utility.py
@@ -346,11 +346,12 @@ def select_window_degen(E, thresh=1e-2, win_min=np.inf, win_max=-np.inf,
 
 def arr_to_string(arr, fmt="{:+9.6f}"):
     string = ""
-    for line in arr:
+    for i, line in enumerate(arr):
         for a in line:
             if isinstance(a, complex):
                 string += fmt.format(a.real) + fmt.format(abs(a.imag)) + "j "
             else:
                 string += fmt.format(a)
-        string += "\n"
+        if i < len(arr) - 1:
+            string += "\n"
     return string

--- a/wannierberri/utility.py
+++ b/wannierberri/utility.py
@@ -80,10 +80,15 @@ def real_recip_lattice(real_lattice=None, recip_lattice=None):
     return np.array(real_lattice), np.array(recip_lattice)
 
 
-def clear_cached(obj, properties=()):
+def clear_cached(obj, properties=None):
+    if properties is None:
+        properties = []
+    elif isinstance(properties, str):
+        properties = [properties, ]
+    assert type(properties) in (list, tuple), f"properties should be list or tuple, got {type(properties)}"
     for attr in properties:
-        if hasattr(obj, attr):
-            delattr(obj, attr)
+        if attr in obj.__dict__:
+            del obj.__dict__[attr]
 
 
 def str2bool(v):
@@ -337,3 +342,15 @@ def select_window_degen(E, thresh=1e-2, win_min=np.inf, win_max=-np.inf,
         inside = np.zeros(E.shape, dtype=bool)
         inside[ind] = True
         return inside
+
+
+def arr_to_string(arr, fmt="{:+9.6f}"):
+    string = ""
+    for line in arr:
+        for a in line:
+            if isinstance(a, complex):
+                string += fmt.format(a.real)  + fmt.format(abs(a.imag)) + "j "
+            else:
+                string += fmt.format(a)
+        string += "\n"
+    return string

--- a/wannierberri/utility.py
+++ b/wannierberri/utility.py
@@ -349,7 +349,7 @@ def arr_to_string(arr, fmt="{:+9.6f}"):
     for line in arr:
         for a in line:
             if isinstance(a, complex):
-                string += fmt.format(a.real)  + fmt.format(abs(a.imag)) + "j "
+                string += fmt.format(a.real) + fmt.format(abs(a.imag)) + "j "
             else:
                 string += fmt.format(a)
         string += "\n"

--- a/wannierberri/utils/vaspspn.py
+++ b/wannierberri/utils/vaspspn.py
@@ -138,7 +138,7 @@ def main(argv):
         WF = np.zeros((npw, NBout), dtype=complex)
         for ib in range(NBout):
             WF[:, ib] = record(3 + ik * (NBin + 1) + ib + IBstart, npw, np.complex64)
-       
+
         if normalize == "norm":
             WF /= np.linalg.norm(WF, axis=0)[None, :]
 

--- a/wannierberri/w90files/chk.py
+++ b/wannierberri/w90files/chk.py
@@ -386,7 +386,7 @@ class CheckPoint(SavableNPZ):
                 mmn_loc = self.wannier_gauge(mmn.data[ik][ib], ik, iknb)
                 mmn_loc = mmn_loc.diagonal()
                 log_loc = np.angle(mmn_loc)
-                wcc += -log_loc[:, None] * mmn.wk[ib] * mmn.bk_cart[ib][None,:]
+                wcc += -log_loc[:, None] * mmn.wk[ib] * mmn.bk_cart[ib][None, :]
                 if spreads:
                     r2 += (1 - np.abs(mmn_loc) ** 2 + log_loc ** 2) * mmn.wk[ib]
         wcc /= mmn.NK

--- a/wannierberri/w90files/chk.py
+++ b/wannierberri/w90files/chk.py
@@ -103,6 +103,10 @@ class CheckPoint(SavableNPZ):
         self.num_bands = num_bands
         self.num_kpts = num_kpts
 
+    @property
+    def NK(self):
+        return self.num_kpts
+
 
 
 
@@ -382,7 +386,7 @@ class CheckPoint(SavableNPZ):
                 mmn_loc = self.wannier_gauge(mmn.data[ik][ib], ik, iknb)
                 mmn_loc = mmn_loc.diagonal()
                 log_loc = np.angle(mmn_loc)
-                wcc += -log_loc[:, None] * mmn.wk[ib] * mmn.bk_cart[ib]
+                wcc += -log_loc[:, None] * mmn.wk[ib] * mmn.bk_cart[ib][None,:]
                 if spreads:
                     r2 += (1 - np.abs(mmn_loc) ** 2 + log_loc ** 2) * mmn.wk[ib]
         wcc /= mmn.NK

--- a/wannierberri/w90files/chk.py
+++ b/wannierberri/w90files/chk.py
@@ -378,8 +378,8 @@ class CheckPoint(SavableNPZ):
             r2 = np.zeros(self.num_wann, dtype=float)
         for ik in range(mmn.NK):
             for ib in range(mmn.NNB):
-                iknb = mmn.neighbours[ik, ib]
-                mmn_loc = self.wannier_gauge(mmn.data[ik, ib], ik, iknb)
+                iknb = mmn.neighbours[ik][ib]
+                mmn_loc = self.wannier_gauge(mmn.data[ik][ib], ik, iknb)
                 mmn_loc = mmn_loc.diagonal()
                 log_loc = np.angle(mmn_loc)
                 wcc += -log_loc[:, None] * mmn.wk[ib] * mmn.bk_cart[ib]

--- a/wannierberri/w90files/mmn.py
+++ b/wannierberri/w90files/mmn.py
@@ -131,10 +131,10 @@ class MMN(W90_file):
         f_mmn_out.write(f"{self.NB} {self.NK} {self.NNB}\n")
         for ik in range(self.NK):
             for ib in range(self.NNB):
-                f_mmn_out.write(f"{ik + 1} {self.neighbours[ik, ib] + 1} {' '.join(map(str, self.G[ik, ib]))}\n")
+                f_mmn_out.write(f"{ik + 1} {self.neighbours[ik, ib] + 1} {' '.join(map(str, self.G[ik][ib]))}\n")
                 for m in range(self.NB):
                     for n in range(self.NB):
-                        f_mmn_out.write(f"{self.data[ik, ib, n, m].real} {self.data[ik, ib, n, m].imag}\n")
+                        f_mmn_out.write(f"{self.data[ik][ib, n, m].real} {self.data[ik][ib, n, m].imag}\n")
         f_mmn_out.close()
 
     def select_bands(self, selected_bands):

--- a/wannierberri/w90files/unk.py
+++ b/wannierberri/w90files/unk.py
@@ -95,8 +95,8 @@ class UNK(W90_file):
                 for js in range(nspinor):
                     U[ib, :, :, :, js] = f.read_record(dtype=np.complex128).reshape(
                         nr1, nr2, nr3, order='F')[::reduce_grid[0], ::reduce_grid[1], ::reduce_grid[2]]
-                    print(f"norm of band {ib} (spinor {js}) = {np.linalg.norm(U[ib, :, :, :, js])}")
-                print(f"norm of band {ib} = {np.linalg.norm(U[ib, :, :, :, :])}")
+                #     print(f"norm of band {ib} (spinor {js}) = {np.linalg.norm(U[ib, :, :, :, js])}")
+                # print(f"norm of band {ib} = {np.linalg.norm(U[ib, :, :, :, :])}")
             data[ik] = U
         return UNK(data=data, NK=NK)
 

--- a/wannierberri/w90files/w90data.py
+++ b/wannierberri/w90files/w90data.py
@@ -195,7 +195,7 @@ class Wannier90data:
             if hasattr(self.symmetrizer, "selected_kpoints"):
                 selected_kpoints = self.symmetrizer.selected_kpoints
             else:
-                selected_kpoints = np.arange(bandstructure.num_kpts)
+                selected_kpoints = np.arange(bandstructure.num_k)
         else:
             kpt_latt = np.array([kp.k for kp in bandstructure.kpoints])
             mp_grid = grid_from_kpoints(kpt_latt)

--- a/wannierberri/wannierise/wannierise.py
+++ b/wannierberri/wannierise/wannierise.py
@@ -23,7 +23,7 @@ def wannierise(w90data,
                parallel=True,
                symmetrize_Z=True,
                irreducible=False,
-                print_wcc_chk=False,
+               print_wcc_chk=False,
                ):
     r"""
     Performs disentanglement and maximal localization of the bands recorded in w90data.

--- a/wannierberri/wannierise/wannierise.py
+++ b/wannierberri/wannierise/wannierise.py
@@ -22,7 +22,8 @@ def wannierise(w90data,
                num_wann=None,
                parallel=True,
                symmetrize_Z=True,
-               irreducible=False
+               irreducible=False,
+                print_wcc_chk=False,
                ):
     r"""
     Performs disentanglement and maximal localization of the bands recorded in w90data.
@@ -201,7 +202,8 @@ def wannierise(w90data,
 
     U_opt_full_BZ = symmetrizer.U_to_full_BZ(U_opt_full_IR, include_k=include_k if irreducible else None)
     print_centers_and_spreads(wcc=wcc, spreads=spreads, comment="Final state (from wannierizer)", std=delta_std)
-    update_chk(w90data=w90data, U_opt_full_BZ=U_opt_full_BZ, wcc=wcc, spreads=spreads)
+    update_chk(w90data=w90data, U_opt_full_BZ=U_opt_full_BZ, wcc=wcc, spreads=spreads, print_wcc=print_wcc_chk)
+    # w90data.chk.get_wannier_centers(w90data.mmn, spreads=True)
     #    comment="Final state (from chk)")
     # if not np.allclose(wcc, wcc_chk, atol=1e-4):
     #     warnings.warn(f"The Wannier centers from the chk file and the Wannier centers from the wannierizer are not the same. diff = {np.abs(wcc - wcc_chk).max()}")
@@ -234,7 +236,7 @@ def update_chk(w90data, U_opt_full_BZ,
     """
 
     w90data.chk.v_matrix = {ik: U for ik, U in enumerate(U_opt_full_BZ) if U is not None}
-    if (wcc is None) or (spreads is None):
+    if (wcc is None) or (spreads is None) or print_wcc:
         wcc_new, spreads_new = w90data.chk.get_wannier_centers(w90data.mmn, spreads=True)
         if wcc is None:
             wcc = wcc_new
@@ -242,7 +244,7 @@ def update_chk(w90data, U_opt_full_BZ,
             spreads = spreads_new
     w90data.chk.wannier_centers_cart, w90data.chk.wannier_spreads = wcc, spreads
     if print_wcc:
-        print_centers_and_spreads(wcc, spreads, comment=comment + ": from chk")
+        print_centers_and_spreads(wcc_new, spreads_new, comment=comment + ": from chk")
     return wcc, spreads
 
 

--- a/wannierberri/wannierise/wannierise.py
+++ b/wannierberri/wannierise/wannierise.py
@@ -127,7 +127,7 @@ def wannierise(w90data,
         if sitesym:
             num_wann = symmetrizer.num_wann
         else:
-            assert num_wann is not None, "num_wann should be provided for random initialization without sitesymmetry"
+            assert num_wann is not None, "num_wann should be provided for random initialization without site-symmetry"
         amnshape = (w90data.mmn.NK, w90data.mmn.NB, num_wann)
         amn = np.random.random(amnshape) + 1j * np.random.random(amnshape)
         w90data.chk.num_wann = num_wann

--- a/wannierberri/wannierise/wannierise.py
+++ b/wannierberri/wannierise/wannierise.py
@@ -1,4 +1,5 @@
 from time import time
+import warnings
 import numpy as np
 
 from ..symmetry.sawf_kirr import get_symmetrizer_Zirr, get_symmetrizer_Uirr
@@ -203,8 +204,14 @@ def wannierise(w90data,
     U_opt_full_BZ = symmetrizer.U_to_full_BZ(U_opt_full_IR, include_k=include_k if irreducible else None)
     print_centers_and_spreads(wcc=wcc, spreads=spreads, comment="Final state (from wannierizer)", std=delta_std)
     update_chk(w90data=w90data, U_opt_full_BZ=U_opt_full_BZ, wcc=wcc, spreads=spreads, print_wcc=print_wcc_chk)
-    wcc, spreads = w90data.chk.get_wannier_centers(w90data.mmn, spreads=True)
-    print_centers_and_spreads(wcc=wcc, spreads=spreads, comment="Final state (from chk)")
+    if not irreducible:
+        wcc_chk, spreads_chk = w90data.chk.get_wannier_centers(w90data.mmn, spreads=True)
+        print_centers_and_spreads(wcc=wcc_chk, spreads=spreads_chk, comment="Final state (from chk)")
+        if not np.allclose(wcc, wcc_chk, atol=1e-6):
+            warnings.warn(f"The Wannier centers from the chk file and the Wannier centers from the wannierizer are not the same. diff = {np.abs(wcc - wcc_chk).max()}")
+        if not np.allclose(spreads, spreads_chk, atol=1e-2):
+            warnings.warn(f"The Wannier spreads from the chk file and the Wannier spreads from the wannierizer are not the same. diff = {np.abs(spreads - spreads_chk).max()}")
+
     # if not np.allclose(wcc, wcc_chk, atol=1e-4):
     #     warnings.warn(f"The Wannier centers from the chk file and the Wannier centers from the wannierizer are not the same. diff = {np.abs(wcc - wcc_chk).max()}")
     # if not np.allclose(spreads, spreads_chk, atol=1e-4):

--- a/wannierberri/wannierise/wannierise.py
+++ b/wannierberri/wannierise/wannierise.py
@@ -203,8 +203,8 @@ def wannierise(w90data,
     U_opt_full_BZ = symmetrizer.U_to_full_BZ(U_opt_full_IR, include_k=include_k if irreducible else None)
     print_centers_and_spreads(wcc=wcc, spreads=spreads, comment="Final state (from wannierizer)", std=delta_std)
     update_chk(w90data=w90data, U_opt_full_BZ=U_opt_full_BZ, wcc=wcc, spreads=spreads, print_wcc=print_wcc_chk)
-    # w90data.chk.get_wannier_centers(w90data.mmn, spreads=True)
-    #    comment="Final state (from chk)")
+    wcc, spreads = w90data.chk.get_wannier_centers(w90data.mmn, spreads=True)
+    print_centers_and_spreads(wcc=wcc, spreads=spreads, comment="Final state (from chk)")
     # if not np.allclose(wcc, wcc_chk, atol=1e-4):
     #     warnings.warn(f"The Wannier centers from the chk file and the Wannier centers from the wannierizer are not the same. diff = {np.abs(wcc - wcc_chk).max()}")
     # if not np.allclose(spreads, spreads_chk, atol=1e-4):


### PR DESCRIPTION
Fixes a series of bugs that made the SAWF inaccurate:

1) Checking explicitly the Symmetrizer_Uirr, abd excluding the blocks which do nbot symmetrize accurately (usually those are the upper block, where the nbands cuts through an irrep0
2) iteratively symmetrize+orthogonalize (until convergence is reached)
3) require irrep>=2.3.3
4) require python >=3.11
5) allow to use certain symmetries from spacegroup, in creating the pointgroup, and in symmetrize2
6) clear cached inverse after select_bands in symmetrizer
7) check_mmn, check_amn
8) self-checking the symmetrizer in Uirr
9) modified clear_cached, to NOT call the object that it was creating