### PR TITLE
fix wrong return type in VoidSymmetrizer

### DIFF
--- a/wannierberri/symmetry/sawf.py
+++ b/wannierberri/symmetry/sawf.py
@@ -922,4 +922,4 @@ class VoidSymmetrizer(SymmetrizerSAWF):
         return wannier_property
 
     def select_full_blocks(self, selected_bands_bool, include_partial_blocks=False):
-        return np.copy(selected_bands_bool), None
+        return np.copy(selected_bands_bool)


### PR DESCRIPTION
Calling `wannierberri.wannierise.wannierise` was broken on master without a symmetrizer, because `select_full_blocks` for the dummy `VoidSymmetrizer` returned a tuple with None, while the symmetrizer only returns the `selected_bands_pool`. 

I don't know the code base so I'm not sure if I am missing something important, but this seems to work. 