### PR TITLE
update docs and spglib function

### DIFF
--- a/tests/test_formula.py
+++ b/tests/test_formula.py
@@ -123,7 +123,8 @@ def check_formula_output():
                 continue
             maxval = np.max(abs(val))
             if maxval < atol_zero:
-                assert np.allclose(val_out, 0, atol=atol_zero), f"{filename} key {k} is expected to be zero, but max value is {maxval} > {atol_zero}"
+                maxval_out = np.max(abs(val_out))
+                assert maxval_out < atol_zero, f"{filename} key {k} is expected to be zero, but max value is {maxval_out} > {atol_zero}"
             else:
                 adiff = np.max(abs(val - val_out))
                 rdiff = adiff / maxval

--- a/tests/test_point_symmetry.py
+++ b/tests/test_point_symmetry.py
@@ -58,8 +58,6 @@ def test_symmetry_spglib_GaAs(system_GaAs_W90, check_pointgroup_equal):
 def test_symmetry_spglib_Fe(system_Fe_W90, check_pointgroup_equal):
     system_explicit = deepcopy(system_Fe_W90)
 
-    # Magnetic symmetries involving time-reversal is not implemented in spglib.
-    # So, we exclude symmetries involving time reversal from the generators.
     import spglib
     if pversion(spglib.__version__) < pversion("2"):
         symmetries_Fe_except_TR = [sym for sym in symmetries_Fe if not sym.TR]

--- a/tests/test_sym_wann.py
+++ b/tests/test_sym_wann.py
@@ -435,7 +435,8 @@ def test_symmetrization_model(ibasis1, ibasis2, include_TR):
 
     norb = proj.num_wann_per_site
 
-    print(f"basis list : \n{"\n".join(str(a) for a in proj_set.projections[0].basis_list)}")
+    basis_str = '\n'.join(str(a) for a in proj_set.projections[0].basis_list)
+    print(f"basis list : \n{basis_str}")
 
 
     symmetrizer = SAWF().set_spacegroup(sg).set_D_wann_from_projections(proj_set)

--- a/wannierberri/system/system.py
+++ b/wannierberri/system/system.py
@@ -271,13 +271,14 @@ class System:
         """
         Set the symmetry group of the :class:`System`. Requires spglib to be installed.
         :meth:`System.set_structure` must be called in advance.
-
-        For magnetic systems, symmetries involving time reversal are not detected because
-        spglib does not support time reversal symmetry for noncollinear systems.
         """
         import spglib
 
-        spglib_symmetry = spglib.get_symmetry(self.get_spglib_cell())
+        cell = self.get_spglib_cell()
+        if self.magnetic_moments is None:
+            spglib_symmetry = spglib.get_symmetry(cell)
+        else:
+            spglib_symmetry = spglib.get_magnetic_symmetry(cell)
         symmetry_gen = []
         for isym, W in enumerate(spglib_symmetry["rotations"]):
             # spglib gives real-space rotations in reduced coordinates. Here,
@@ -299,13 +300,10 @@ class System:
         elif not tr_found:
             warnings.warn(
                 "you specified magnetic moments but spglib did not detect symmetries involving time-reversal. "
-                f"proobably it is because you have an old spglib version {spglib.__version__}."
-                "We suggest upgrading to spglib>=2.0.2")
-        else:
-            if not all([len(x) for x in self.magnetic_moments]):
-                raise ValueError("magnetic_moments must be a list of 3d vector")
-            warnings.warn("spglib does not find symmetries including time reversal operation. "
-                          "To include such symmetries, use set_symmetry.")
+                f"probably it is because you have an old spglib version {spglib.__version__}. "
+                "we suggest upgrading to spglib>=2.0.2")
+        elif not all([len(x) for x in self.magnetic_moments]):
+            raise ValueError("magnetic_moments must be a list of 3d vector")
 
 
         self.pointgroup = PointGroup(symmetry_gen, recip_lattice=self.recip_lattice, real_lattice=self.real_lattice)


### PR DESCRIPTION
Changes:
- Update spglib calls in `System.set_pointgroup_from_structure`
  - Obtain `cell = self.get_spglib_cell()` and, if `self.magnetic_moments is None`, call `spglib.get_symmetry(cell)`, otherwise call `spglib.get_magnetic_symmetry(cell)`, so that magnetic symmetry (including time-reversal) for magnetic systems is handled automatically with spglib ≥ 2.

- Update docstring and warning messages in `set_pointgroup_from_structure`
  - Remove the old explanation that “for magnetic systems, symmetries involving time reversal are not detected by spglib,” which reflected the previous behavior.

- Clean up comments in `tests/test_point_symmetry.py::test_symmetry_spglib_Fe`
  - Delete the comment that “magnetic symmetries involving time-reversal are not implemented in spglib, so we exclude such symmetries from the generators”, while leaving the actual test logic (e.g. `symmetries_Fe_except_TR`) unchanged.
