### PR TITLE
Fix missing bkvec argument in update_chk() get_wannier_centers call

### DIFF
--- a/wannierberri/wannierisation/wannierise.py
+++ b/wannierberri/wannierisation/wannierise.py
@@ -324,7 +324,7 @@ def update_chk(wandata, U_opt_full_BZ,
 
     wandata.chk.v_matrix = {ik: U for ik, U in enumerate(U_opt_full_BZ) if U is not None}
     if (wcc is None) or (spreads is None) or print_wcc:
-        wcc_new, spreads_new = wandata.chk.get_wannier_centers(wandata.mmn, spreads=True)
+        wcc_new, spreads_new = wandata.chk.get_wannier_centers(wandata.bkvec, wandata.mmn, spreads=True)
         if wcc is None:
             wcc = wcc_new
         if spreads is None:


### PR DESCRIPTION
Fixes the missing positional `bkvec` argument in the `update_chk()` 
call at `wannierberri/wannierisation/wannierise.py` line 325, where 
`wandata.chk.get_wannier_centers(wandata.mmn, spreads=True)` was 
binding `wandata.mmn` to the `bkvec` parameter and leaving `mmn` 
unset.

Originally reported in #548 (secondary bug section). The fix matches 
the proposed one-liner there.

Triggering conditions: any caller that enters the branch with 
`wcc=None`, `spreads=None`, or `print_wcc=True`. `wannierise()` 
itself always passes non-None `wcc` and `spreads`, so the bug is not 
hit by default but will surface for any user with `print_wcc_chk=True`.

No tests added — the branch is currently unreachable by the default 
wannierise() path, so existing tests don't exercise it; a focused 
unit test for this branch could be added in a follow-up if 
maintainers prefer.