### PR TITLE
Fix/select window degen mask

### DIFF
--- a/tests/test_select_window_degen.py
+++ b/tests/test_select_window_degen.py
@@ -7,7 +7,8 @@ from wannierberri.utility import select_window_degen
 
 # bands 6 and 7 are degenerate (gap 1 meV << thresh = 10 meV)
 E_DEGEN = np.array([-5., -4., -3., -2., -1., 0., 1., 1.001, 3., 4.])
- 
+# bands 1 and 2 are degenerate -- lower edge
+E_DEGEN_LOW = np.array([-5., -4.001, -4.0, -2., -1., 0., 1., 2., 3., 4.])
  
 @pytest.mark.parametrize("include_degen", [True, False])
 def test_edge_cutting_multiplet_does_not_raise(include_degen):
@@ -37,15 +38,23 @@ def test_mask_and_indices_agree(include_degen, win_max):
     assert np.array_equal(np.where(mask)[0], np.array(sorted(ind), dtype=int))
  
  
-def test_degenerate_pair_not_split():
-    """A degenerate multiplet is either fully in or fully out of the selection."""
-    for win_max in (0.999, 1.0, 1.0005, 1.001):
-        for include_degen in (True, False):
-            mask = select_window_degen(E_DEGEN, win_min=-6, win_max=win_max,
-                                       include_degen=include_degen)
-            assert mask[6] == mask[7], (
-                f"bands 6,7 are degenerate but selection split them "
-                f"(win_max={win_max}, include_degen={include_degen})")
+@pytest.mark.parametrize("include_degen", [True, False])
+@pytest.mark.parametrize("E,pair,win", [
+    # upper window edge cutting the degenerate pair (bands 6,7)
+    *[(E_DEGEN, (6, 7), (-6.0, wmax)) for wmax in (0.999, 1.0, 1.0005, 1.001)],
+    # lower window edge cutting the degenerate pair (bands 1,2)
+    *[(E_DEGEN_LOW, (1, 2), (wmin, 5.0)) for wmin in (-4.002, -4.0005, -4.0)],
+])
+def test_degenerate_pair_not_split(E, pair, win, include_degen):
+    """A degenerate multiplet is either fully in or fully out of the selection,
+    whether it straddles the upper or the lower window edge."""
+    i, j = pair
+    win_min, win_max = win
+    mask = select_window_degen(E, win_min=win_min, win_max=win_max,
+                               include_degen=include_degen)
+    assert mask[i] == mask[j], (
+        f"bands {i},{j} are degenerate but the selection split them "
+        f"(window=({win_min}, {win_max}), include_degen={include_degen})")
  
  
 def test_unaffected_cases_unchanged():
@@ -62,4 +71,8 @@ def test_empty_window():
     assert select_window_degen(E_DEGEN, win_min=10, win_max=20,
                                return_indices=True) == []
     assert not select_window_degen(E_DEGEN, win_min=10, win_max=20).any()
- 
+
+def test_degeneracy_between_bands_0_and_1():
+    E = np.array([-4.001, -4.0, -2., -1., 0., 1.])   # bands 0,1 degenerate
+    mask = select_window_degen(E, win_min=-4.0005, win_max=2.0, include_degen=True)
+    assert mask[0] == mask[1], "degeneracy between bands 0 and 1 was not handled"

--- a/tests/test_select_window_degen.py
+++ b/tests/test_select_window_degen.py
@@ -9,12 +9,14 @@ from wannierberri.utility import select_window_degen
 E_DEGEN = np.array([-5., -4., -3., -2., -1., 0., 1., 1.001, 3., 4.])
 # bands 1 and 2 are degenerate -- lower edge
 E_DEGEN_LOW = np.array([-5., -4.001, -4.0, -2., -1., 0., 1., 2., 3., 4.])
- 
+
+
 @pytest.mark.parametrize("include_degen", [True, False])
 def test_edge_cutting_multiplet_does_not_raise(include_degen):
     """Window edge inside a degenerate pair must not raise."""
     select_window_degen(E_DEGEN, win_min=-6, win_max=1.0,
                         include_degen=include_degen, return_indices=True)
+
 
 @pytest.mark.parametrize("include_degen", [True, False])
 @pytest.mark.parametrize("win_min", [-6.0, -2.5])   # selection from band 0
@@ -27,6 +29,7 @@ def test_indices_are_unique_and_sorted(include_degen, win_min):
     assert ind == sorted(ind)
     assert all(0 <= i < len(E_DEGEN) for i in ind)
 
+
 @pytest.mark.parametrize("include_degen", [True, False])
 @pytest.mark.parametrize("win_max", [0.5, 1.0, 2.0, 5.0])
 def test_mask_and_indices_agree(include_degen, win_max):
@@ -36,8 +39,8 @@ def test_mask_and_indices_agree(include_degen, win_max):
     mask = select_window_degen(E_DEGEN, win_min=-6, win_max=win_max,
                                include_degen=include_degen, return_indices=False)
     assert np.array_equal(np.where(mask)[0], np.array(sorted(ind), dtype=int))
- 
- 
+
+
 @pytest.mark.parametrize("include_degen", [True, False])
 @pytest.mark.parametrize("E,pair,win", [
     # upper window edge cutting the degenerate pair (bands 6,7)
@@ -55,8 +58,8 @@ def test_degenerate_pair_not_split(E, pair, win, include_degen):
     assert mask[i] == mask[j], (
         f"bands {i},{j} are degenerate but the selection split them "
         f"(window=({win_min}, {win_max}), include_degen={include_degen})")
- 
- 
+
+
 def test_unaffected_cases_unchanged():
     """Edges sitting in real gaps keep the original behaviour."""
     ind = select_window_degen(E_DEGEN, win_min=-6, win_max=0.5,
@@ -65,12 +68,13 @@ def test_unaffected_cases_unchanged():
     ind = select_window_degen(E_DEGEN, win_min=-6, win_max=5.0,
                               include_degen=True, return_indices=True)
     assert list(ind) == list(range(len(E_DEGEN)))
- 
- 
+
+
 def test_empty_window():
     assert select_window_degen(E_DEGEN, win_min=10, win_max=20,
                                return_indices=True) == []
     assert not select_window_degen(E_DEGEN, win_min=10, win_max=20).any()
+
 
 def test_degeneracy_between_bands_0_and_1():
     E = np.array([-4.001, -4.0, -2., -1., 0., 1.])   # bands 0,1 degenerate

--- a/tests/test_select_window_degen.py
+++ b/tests/test_select_window_degen.py
@@ -1,0 +1,65 @@
+"""Test the select_window_degen function"""
+
+import numpy as np
+import pytest
+
+from wannierberri.utility import select_window_degen
+
+# bands 6 and 7 are degenerate (gap 1 meV << thresh = 10 meV)
+E_DEGEN = np.array([-5., -4., -3., -2., -1., 0., 1., 1.001, 3., 4.])
+ 
+ 
+@pytest.mark.parametrize("include_degen", [True, False])
+def test_edge_cutting_multiplet_does_not_raise(include_degen):
+    """Window edge inside a degenerate pair must not raise."""
+    select_window_degen(E_DEGEN, win_min=-6, win_max=1.0,
+                        include_degen=include_degen, return_indices=True)
+
+@pytest.mark.parametrize("include_degen", [True, False])
+@pytest.mark.parametrize("win_min", [-6.0, -2.5])   # selection from band 0
+def test_indices_are_unique_and_sorted(include_degen, win_min):
+    """The returned index list must be a valid, duplicate-free band selection."""
+    ind = select_window_degen(E_DEGEN, win_min=win_min, win_max=1.0,
+                              include_degen=include_degen, return_indices=True)
+    ind = list(ind)
+    assert len(ind) == len(set(ind)), f"duplicated band indices: {ind}"
+    assert ind == sorted(ind)
+    assert all(0 <= i < len(E_DEGEN) for i in ind)
+
+@pytest.mark.parametrize("include_degen", [True, False])
+@pytest.mark.parametrize("win_max", [0.5, 1.0, 2.0, 5.0])
+def test_mask_and_indices_agree(include_degen, win_max):
+    """return_indices=True and the boolean mask must describe the same set."""
+    ind = select_window_degen(E_DEGEN, win_min=-6, win_max=win_max,
+                              include_degen=include_degen, return_indices=True)
+    mask = select_window_degen(E_DEGEN, win_min=-6, win_max=win_max,
+                               include_degen=include_degen, return_indices=False)
+    assert np.array_equal(np.where(mask)[0], np.array(sorted(ind), dtype=int))
+ 
+ 
+def test_degenerate_pair_not_split():
+    """A degenerate multiplet is either fully in or fully out of the selection."""
+    for win_max in (0.999, 1.0, 1.0005, 1.001):
+        for include_degen in (True, False):
+            mask = select_window_degen(E_DEGEN, win_min=-6, win_max=win_max,
+                                       include_degen=include_degen)
+            assert mask[6] == mask[7], (
+                f"bands 6,7 are degenerate but selection split them "
+                f"(win_max={win_max}, include_degen={include_degen})")
+ 
+ 
+def test_unaffected_cases_unchanged():
+    """Edges sitting in real gaps keep the original behaviour."""
+    ind = select_window_degen(E_DEGEN, win_min=-6, win_max=0.5,
+                              include_degen=True, return_indices=True)
+    assert list(ind) == [0, 1, 2, 3, 4, 5]
+    ind = select_window_degen(E_DEGEN, win_min=-6, win_max=5.0,
+                              include_degen=True, return_indices=True)
+    assert list(ind) == list(range(len(E_DEGEN)))
+ 
+ 
+def test_empty_window():
+    assert select_window_degen(E_DEGEN, win_min=10, win_max=20,
+                               return_indices=True) == []
+    assert not select_window_degen(E_DEGEN, win_min=10, win_max=20).any()
+ 

--- a/wannierberri/utility.py
+++ b/wannierberri/utility.py
@@ -302,7 +302,8 @@ def select_window_degen(E, thresh=1e-2, win_min=np.inf, win_max=-np.inf,
         the boolean array of the frozen bands  (True for frozen)
     """
     NB = len(E)
-    ind = list(np.where((E <= win_max) * (E >= win_min))[0])
+    inside = (E <= win_max) & (E >= win_min)          
+    ind = list(np.where(inside)[0])
     if len(ind) == 0:
         if return_indices:
             return []
@@ -313,28 +314,26 @@ def select_window_degen(E, thresh=1e-2, win_min=np.inf, win_max=-np.inf,
     for i in range(ind[-1], NB - 1):
         if E[i + 1] - E[i] < thresh:
             if include_degen:
-                ind[i + 1] = True
+                inside[i + 1] = True
             else:
-                ind[i] = False
+                inside[i] = False
                 break
         else:
             break
 
     # The lower bound
-    for i in range(ind[0], 1, -1):
+    for i in range(ind[0], 0, -1):
         if E[i] - E[i - 1] < thresh:
             if include_degen:
-                ind[i - 1] = True
+                inside[i - 1] = True
             else:
-                ind[i] = False
+                inside[i] = False
                 break
         else:
             break
     if return_indices:
-        return ind
+        return list(np.where(inside)[0])
     else:
-        inside = np.zeros(E.shape, dtype=bool)
-        inside[ind] = True
         return inside
 
 


### PR DESCRIPTION
The function `select_window_degen` in `utility.py` raised an `IndexError` (reached from `wannierise` L132), when the outer window's upper limit sat right between two degenerate bands. It could also fail silently, by dropping the degenerate bands in case of the failure occurring at the lower limit of the window. This was caused by a list of indexes being used as a mask. 
It could also return wrong indices with `return_indices=True`, as it assigned `False`instead of the index, omitting the real index and potentially duplicating 0. This could lead to some failure in `EBRsearcher.set_irreps_dft`.

It was fixed by using a separate mask, from which the indices are then retrieved. A small fix was also made on line 324, to set the end index to 0 instead of 1 as it is not included in `range`.  A test file `test_select_window_degen.py` was also added, that tests the main features of the fix.
