### PR TITLE
Fix/type normalization

### DIFF
--- a/tests/test_aux.py
+++ b/tests/test_aux.py
@@ -5,7 +5,11 @@ from pytest import approx
 import pytest
 from wannierberri.formula.covariant import _spin_velocity_einsum_opt
 from wannierberri.symmetry.sym_wann_2 import _rotate_matrix
-from wannierberri.utility import cached_einsum, vectorize, arr_to_string
+from wannierberri.utility import cached_einsum, vectorize, arr_to_string, normalize_type
+from wannierberri.symmetry.sawf import SymmetrizerSAWF
+from .common import ROOT_DIR
+import os
+
 
 
 def test_spin_velocity_einsum_opt():
@@ -68,3 +72,15 @@ def test_rotate_matrix():
             assert Y.shape == X.shape
             Z = cached_einsum("ij,jk...,kl->il...", L, X, R)
             assert np.allclose(Y, Z), f"for num_wann={num_wann}, num_cart={num_cart}, the difference is {np.max(np.abs(Y - Z))} Y.shape={Y.shape} X.shape = {X.shape}\nX={X}\nY={Y}\nZ={Z}"
+
+
+def test_normalize_type():
+    assert normalize_type(np.array(5)) == 5
+    assert normalize_type(np.array(5.0)) == 5.0
+    assert normalize_type(np.array("test")) == "test"
+    assert normalize_type({"a": np.array(1), "b": np.array(2)}) == {"a": 1, "b": 2}
+    assert normalize_type({"a": np.array(1), "b": {"c": np.array(2)}}) == {"a": 1, "b": {"c": 2}}
+    sawf_path = os.path.join(ROOT_DIR, "data", "diamond", "diamond.sawf.npz")
+    symm = SymmetrizerSAWF.from_npz(sawf_path)
+    assert isinstance(symm.spacegroup.number, int)
+    assert isinstance(symm.spacegroup.number_str, str)

--- a/tests/test_aux.py
+++ b/tests/test_aux.py
@@ -75,11 +75,19 @@ def test_rotate_matrix():
 
 
 def test_normalize_type():
-    assert normalize_type(np.array(5)) == 5
-    assert normalize_type(np.array(5.0)) == 5.0
-    assert normalize_type(np.array("test")) == "test"
-    assert normalize_type({"a": np.array(1), "b": np.array(2)}) == {"a": 1, "b": 2}
-    assert normalize_type({"a": np.array(1), "b": {"c": np.array(2)}}) == {"a": 1, "b": {"c": 2}}
+    for val, ref in (
+        (np.array(5), 5),
+        (np.array(5.0), 5.0),
+        (np.array("test"), "test"),
+        ({"a": np.array(1), "b": np.array(2)}, {"a": 1, "b": 2}),
+        ({"a": np.array(1), "b": {"c": np.array(2)}}, {"a": 1, "b": {"c": 2}}),
+    ):
+        normalized = normalize_type(val)
+        assert normalized == ref
+        assert type(normalized) == type(ref)
+        if isinstance(normalized, dict):
+            for k in normalized:
+                assert type(normalized[k]) == type(ref[k])
     sawf_path = os.path.join(ROOT_DIR, "data", "diamond", "diamond.sawf.npz")
     symm = SymmetrizerSAWF.from_npz(sawf_path)
     assert isinstance(symm.spacegroup.number, int)

--- a/tests/test_select_window_degen.py
+++ b/tests/test_select_window_degen.py
@@ -7,7 +7,8 @@ from wannierberri.utility import select_window_degen
 
 # bands 6 and 7 are degenerate (gap 1 meV << thresh = 10 meV)
 E_DEGEN = np.array([-5., -4., -3., -2., -1., 0., 1., 1.001, 3., 4.])
- 
+# bands 1 and 2 are degenerate -- lower edge
+E_DEGEN_LOW = np.array([-5., -4.001, -4.0, -2., -1., 0., 1., 2., 3., 4.])
  
 @pytest.mark.parametrize("include_degen", [True, False])
 def test_edge_cutting_multiplet_does_not_raise(include_degen):
@@ -37,15 +38,23 @@ def test_mask_and_indices_agree(include_degen, win_max):
     assert np.array_equal(np.where(mask)[0], np.array(sorted(ind), dtype=int))
  
  
-def test_degenerate_pair_not_split():
-    """A degenerate multiplet is either fully in or fully out of the selection."""
-    for win_max in (0.999, 1.0, 1.0005, 1.001):
-        for include_degen in (True, False):
-            mask = select_window_degen(E_DEGEN, win_min=-6, win_max=win_max,
-                                       include_degen=include_degen)
-            assert mask[6] == mask[7], (
-                f"bands 6,7 are degenerate but selection split them "
-                f"(win_max={win_max}, include_degen={include_degen})")
+@pytest.mark.parametrize("include_degen", [True, False])
+@pytest.mark.parametrize("E,pair,win", [
+    # upper window edge cutting the degenerate pair (bands 6,7)
+    *[(E_DEGEN, (6, 7), (-6.0, wmax)) for wmax in (0.999, 1.0, 1.0005, 1.001)],
+    # lower window edge cutting the degenerate pair (bands 1,2)
+    *[(E_DEGEN_LOW, (1, 2), (wmin, 5.0)) for wmin in (-4.002, -4.0005, -4.0)],
+])
+def test_degenerate_pair_not_split(E, pair, win, include_degen):
+    """A degenerate multiplet is either fully in or fully out of the selection,
+    whether it straddles the upper or the lower window edge."""
+    i, j = pair
+    win_min, win_max = win
+    mask = select_window_degen(E, win_min=win_min, win_max=win_max,
+                               include_degen=include_degen)
+    assert mask[i] == mask[j], (
+        f"bands {i},{j} are degenerate but the selection split them "
+        f"(window=({win_min}, {win_max}), include_degen={include_degen})")
  
  
 def test_unaffected_cases_unchanged():
@@ -62,4 +71,8 @@ def test_empty_window():
     assert select_window_degen(E_DEGEN, win_min=10, win_max=20,
                                return_indices=True) == []
     assert not select_window_degen(E_DEGEN, win_min=10, win_max=20).any()
- 
+
+def test_degeneracy_between_bands_0_and_1():
+    E = np.array([-4.001, -4.0, -2., -1., 0., 1.])   # bands 0,1 degenerate
+    mask = select_window_degen(E, win_min=-4.0005, win_max=2.0, include_degen=True)
+    assert mask[0] == mask[1], "degeneracy between bands 0 and 1 was not handled"

--- a/tests/test_select_window_degen.py
+++ b/tests/test_select_window_degen.py
@@ -1,0 +1,65 @@
+"""Test the select_window_degen function"""
+
+import numpy as np
+import pytest
+
+from wannierberri.utility import select_window_degen
+
+# bands 6 and 7 are degenerate (gap 1 meV << thresh = 10 meV)
+E_DEGEN = np.array([-5., -4., -3., -2., -1., 0., 1., 1.001, 3., 4.])
+ 
+ 
+@pytest.mark.parametrize("include_degen", [True, False])
+def test_edge_cutting_multiplet_does_not_raise(include_degen):
+    """Window edge inside a degenerate pair must not raise."""
+    select_window_degen(E_DEGEN, win_min=-6, win_max=1.0,
+                        include_degen=include_degen, return_indices=True)
+
+@pytest.mark.parametrize("include_degen", [True, False])
+@pytest.mark.parametrize("win_min", [-6.0, -2.5])   # selection from band 0
+def test_indices_are_unique_and_sorted(include_degen, win_min):
+    """The returned index list must be a valid, duplicate-free band selection."""
+    ind = select_window_degen(E_DEGEN, win_min=win_min, win_max=1.0,
+                              include_degen=include_degen, return_indices=True)
+    ind = list(ind)
+    assert len(ind) == len(set(ind)), f"duplicated band indices: {ind}"
+    assert ind == sorted(ind)
+    assert all(0 <= i < len(E_DEGEN) for i in ind)
+
+@pytest.mark.parametrize("include_degen", [True, False])
+@pytest.mark.parametrize("win_max", [0.5, 1.0, 2.0, 5.0])
+def test_mask_and_indices_agree(include_degen, win_max):
+    """return_indices=True and the boolean mask must describe the same set."""
+    ind = select_window_degen(E_DEGEN, win_min=-6, win_max=win_max,
+                              include_degen=include_degen, return_indices=True)
+    mask = select_window_degen(E_DEGEN, win_min=-6, win_max=win_max,
+                               include_degen=include_degen, return_indices=False)
+    assert np.array_equal(np.where(mask)[0], np.array(sorted(ind), dtype=int))
+ 
+ 
+def test_degenerate_pair_not_split():
+    """A degenerate multiplet is either fully in or fully out of the selection."""
+    for win_max in (0.999, 1.0, 1.0005, 1.001):
+        for include_degen in (True, False):
+            mask = select_window_degen(E_DEGEN, win_min=-6, win_max=win_max,
+                                       include_degen=include_degen)
+            assert mask[6] == mask[7], (
+                f"bands 6,7 are degenerate but selection split them "
+                f"(win_max={win_max}, include_degen={include_degen})")
+ 
+ 
+def test_unaffected_cases_unchanged():
+    """Edges sitting in real gaps keep the original behaviour."""
+    ind = select_window_degen(E_DEGEN, win_min=-6, win_max=0.5,
+                              include_degen=True, return_indices=True)
+    assert list(ind) == [0, 1, 2, 3, 4, 5]
+    ind = select_window_degen(E_DEGEN, win_min=-6, win_max=5.0,
+                              include_degen=True, return_indices=True)
+    assert list(ind) == list(range(len(E_DEGEN)))
+ 
+ 
+def test_empty_window():
+    assert select_window_degen(E_DEGEN, win_min=10, win_max=20,
+                               return_indices=True) == []
+    assert not select_window_degen(E_DEGEN, win_min=10, win_max=20).any()
+ 

--- a/wannierberri/symmetry/sawf.py
+++ b/wannierberri/symmetry/sawf.py
@@ -3,7 +3,7 @@ import warnings
 import numpy as np
 
 
-from ..utility import cached_einsum, clear_cached, arr_to_string
+from ..utility import cached_einsum, clear_cached, arr_to_string, normalize_type
 from .utility import get_inverse_block, rotate_block_matrix
 from .projections import Projection, ProjectionsSet
 from .projections_searcher import EBRsearcher
@@ -406,6 +406,7 @@ class SymmetrizerSAWF:
         return dic
 
     def from_dict(self, dic=None, return_obj=True, **kwargs):
+        dic = {k: normalize_type(v) for k, v in dic.items()} if dic is not None else None
         dic_loc = {}
         cls = self.__class__
         for k in self.__class__.npz_tags:

--- a/wannierberri/utility.py
+++ b/wannierberri/utility.py
@@ -302,7 +302,8 @@ def select_window_degen(E, thresh=1e-2, win_min=np.inf, win_max=-np.inf,
         the boolean array of the frozen bands  (True for frozen)
     """
     NB = len(E)
-    ind = list(np.where((E <= win_max) * (E >= win_min))[0])
+    inside = (E <= win_max) & (E >= win_min)          
+    ind = list(np.where(inside)[0])
     if len(ind) == 0:
         if return_indices:
             return []
@@ -313,28 +314,26 @@ def select_window_degen(E, thresh=1e-2, win_min=np.inf, win_max=-np.inf,
     for i in range(ind[-1], NB - 1):
         if E[i + 1] - E[i] < thresh:
             if include_degen:
-                ind[i + 1] = True
+                inside[i + 1] = True
             else:
-                ind[i] = False
+                inside[i] = False
                 break
         else:
             break
 
     # The lower bound
-    for i in range(ind[0], 1, -1):
+    for i in range(ind[0], 0, -1):
         if E[i] - E[i - 1] < thresh:
             if include_degen:
-                ind[i - 1] = True
+                inside[i - 1] = True
             else:
-                ind[i] = False
+                inside[i] = False
                 break
         else:
             break
     if return_indices:
-        return ind
+        return list(np.where(inside)[0])
     else:
-        inside = np.zeros(E.shape, dtype=bool)
-        inside[ind] = True
         return inside
 
 

--- a/wannierberri/utility.py
+++ b/wannierberri/utility.py
@@ -401,3 +401,12 @@ def weight_select_bands(ib1, ib2, select_bands=None):
         return 1.0
     else:
         return np.sum((select_bands >= ib1) * (select_bands < ib2)) / (ib2 - ib1)
+
+
+def normalize_type(obj, recursive=True):
+    """convert a scalar-like object with np.ndarray type (typically from a file created with np.savez) to a Python scalar"""
+    if isinstance(obj, np.ndarray) and obj.ndim == 0:
+        return obj.item()
+    if recursive and isinstance(obj, dict):
+        return {k: normalize_type(v, recursive=True) for k, v in obj.items()}
+    return obj

--- a/wannierberri/w90files/io.py
+++ b/wannierberri/w90files/io.py
@@ -1,6 +1,7 @@
 # inheriting just in order to have possibility to change default values, without changing the rest of the code
 import abc
 import numpy as np
+from ..utility import normalize_type
 
 
 class SavableNPZ(abc.ABC):
@@ -49,6 +50,7 @@ class SavableNPZ(abc.ABC):
 
     @classmethod
     def from_dict(cls, dic=None, return_obj=True, **kwargs):
+        dic = {k: normalize_type(v) for k, v in dic.items()} if dic is not None else None
         dic_loc = {}
         for k in cls.npz_tags:
             if k in kwargs:

--- a/wannierberri/w90files/io.py
+++ b/wannierberri/w90files/io.py
@@ -50,7 +50,7 @@ class SavableNPZ(abc.ABC):
 
     @classmethod
     def from_dict(cls, dic=None, return_obj=True, **kwargs):
-        dic = {k: normalize_type(v) for k, v in dic.items()} if dic is not None else None
+        dic = {k: normalize_type(v) for k, v in dic.items()} if dic is not None else {}
         dic_loc = {}
         for k in cls.npz_tags:
             if k in kwargs:


### PR DESCRIPTION
## Description

`np.load` can return scalar values as 0-D `numpy.ndarrays`. These were passed unchanged to the reconstructed objects, causing scalar attributes (e.g. `SymmetrizerSAWF.spacegroup.number_str`) to have NumPy array types instead of their original Python scalar types. Due to broadcasting, this was most of the time unnoticed, but it breaks when type specific methods are called, for example 
```python
symmetrizerSAWF.spacegroup.number_str.split('.')
``` 
when initializing an `EBRsearcher` with a `SymmetrizerSAWF` from an `.npz` file. 

## Changes
- Added the function `utility.normalize_type` that converts the type from `np.ndarray` to the native Python type (recursively for the case where there is nested dicts).
- Applied this correction when parsing the loaded dictionaries in `from_dict` in:
    - `symmetry.sawf.py`,
    - `w90files.io.py`.
- Added tests covering the changes.
