### PR TITLE
FIx WyckoffPosition.contains_position: full orbit check

### DIFF
--- a/tests/test_wyckoff_position.py
+++ b/tests/test_wyckoff_position.py
@@ -1,0 +1,36 @@
+import os
+import spglib
+from gpaw import GPAW
+from irrep.spacegroup import SpaceGroup
+from wannierberri.symmetry.wyckoff_position import WyckoffPosition
+from .common import ROOT_DIR
+
+
+try:
+    spglib.error.OLD_ERROR_HANDLING = False
+except AttributeError:
+    pass
+
+
+def test_contains_position():
+    """
+    Checks that two equivalent positions in the diamond structure are contained in the same Wyckoff position. 
+    """
+    data_dir = os.path.join(ROOT_DIR, "data", "diamond-gpaw")
+    calc = GPAW(os.path.join(data_dir, "diamond-nscf-irred.gpw"), txt=None)
+    cell = calc.atoms.cell
+    atomic_positions = calc.atoms.get_scaled_positions()
+    numbers = calc.atoms.numbers
+    lattice = (cell, atomic_positions, numbers)
+    spacegroup = SpaceGroup.from_cell(cell=lattice)
+    atoms_wpos = WyckoffPosition(
+                position_str="0.5,0.5,0.5",
+                spacegroup=spacegroup,
+            )
+    _, std_positions, _ = spglib.standardize_cell(
+        lattice,         
+        to_primitive=True,
+    )
+    assert atoms_wpos.num_points == 2
+    assert atoms_wpos.contains_position(std_positions[0]) == []
+    assert atoms_wpos.contains_position(std_positions[1]) == []

--- a/wannierberri/symmetry/wyckoff_position.py
+++ b/wannierberri/symmetry/wyckoff_position.py
@@ -155,7 +155,7 @@ class WyckoffPosition:
 
     def contains_position(self, position):
         if self.num_free_vars == 0:
-            if all_close_mod1(position, self.positions[0]):
+            if any(all_close_mod1(position, p) for p in self.positions):
                 return []
             else:
                 return None


### PR DESCRIPTION
# Description

The `contains_position` method of `wannierberri.symmetry.wyckoff_position.WyckoffPosition` did not detect positions that were within the orbit of the Wyckoff position, but not the first one (`self.positions[0]`). This did not cause internal failure since its existing usage (`stick_to_atoms`) loops over all atoms and compensates by computing the full orbit once a match is found, but used on its own, it does not allow to faithfully detect whether a position lies within the orbit of the Wyckoff position.

# Changes
- Perform the check over all the positions instead of only the first one,
- added a test that initializes a `WyckoffPosition` and checks that both symmetry-equivalent C atoms in diamond are correctly detected as belonging to it.